### PR TITLE
Please check me on this.

### DIFF
--- a/csaf/vex/cve/2024/cve-2024-6601.json
+++ b/csaf/vex/cve/2024/cve-2024-6601.json
@@ -11,14 +11,24 @@
     "tracking": {
       "id": "CVE-2024-6601",
       "initial_release_date": "2024-07-30T14:59:26Z",
-      "current_release_date": "2024-07-30T14:59:26Z",
+      "current_release_date": "2024-07-30T15:07:04Z",
       "status": "final",
-      "version": "1",
+      "version": "3",
       "revision_history": [
         {
           "date": "2024-07-30T14:59:26Z",
           "number": "1",
           "summary": "Initial version"
+        },
+        {
+          "date": "2024-07-30T15:07:04Z",
+          "number": "2",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2024-07-30T15:07:04Z",
+          "number": "3",
+          "summary": "Updated version"
         }
       ]
     }
@@ -48,6 +58,14 @@
                           "name": "lts-9.2:firefox-115.13.0-3.el9_2.92ciq_lts.src",
                           "product_id": "lts-9.2:firefox-115.13.0-3.el9_2.92ciq_lts.src"
                         }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:thunderbird-115.13.0-3.el9_2.92ciq_lts.src",
+                        "product": {
+                          "name": "lts-9.2:thunderbird-115.13.0-3.el9_2.92ciq_lts.src",
+                          "product_id": "lts-9.2:thunderbird-115.13.0-3.el9_2.92ciq_lts.src"
+                        }
                       }
                     ]
                   },
@@ -62,6 +80,14 @@
                           "name": "lts-9.2:firefox-115.13.0-3.el9_2.92ciq_lts.x86_64",
                           "product_id": "lts-9.2:firefox-115.13.0-3.el9_2.92ciq_lts.x86_64"
                         }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:thunderbird-115.13.0-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:thunderbird-115.13.0-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:thunderbird-115.13.0-3.el9_2.92ciq_lts.x86_64"
+                        }
                       }
                     ]
                   },
@@ -75,6 +101,14 @@
                         "product": {
                           "name": "lts-9.2:firefox-115.13.0-3.el9_2.92ciq_lts.aarch64",
                           "product_id": "lts-9.2:firefox-115.13.0-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:thunderbird-115.13.0-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:thunderbird-115.13.0-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:thunderbird-115.13.0-3.el9_2.92ciq_lts.aarch64"
                         }
                       }
                     ]
@@ -99,8 +133,11 @@
       "product_status": {
         "fixed": [
           "lts-9.2:firefox-115.13.0-3.el9_2.92ciq_lts.src",
+          "lts-9.2:thunderbird-115.13.0-3.el9_2.92ciq_lts.src",
           "lts-9.2:firefox-115.13.0-3.el9_2.92ciq_lts.x86_64",
-          "lts-9.2:firefox-115.13.0-3.el9_2.92ciq_lts.aarch64"
+          "lts-9.2:thunderbird-115.13.0-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:firefox-115.13.0-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:thunderbird-115.13.0-3.el9_2.92ciq_lts.aarch64"
         ]
       },
       "remediations": [
@@ -109,8 +146,11 @@
           "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
           "product_ids": [
             "lts-9.2:firefox-115.13.0-3.el9_2.92ciq_lts.src",
+            "lts-9.2:thunderbird-115.13.0-3.el9_2.92ciq_lts.src",
             "lts-9.2:firefox-115.13.0-3.el9_2.92ciq_lts.x86_64",
-            "lts-9.2:firefox-115.13.0-3.el9_2.92ciq_lts.aarch64"
+            "lts-9.2:thunderbird-115.13.0-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:firefox-115.13.0-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:thunderbird-115.13.0-3.el9_2.92ciq_lts.aarch64"
           ]
         }
       ]

--- a/csaf/vex/cve/2024/cve-2024-6603.json
+++ b/csaf/vex/cve/2024/cve-2024-6603.json
@@ -11,14 +11,19 @@
     "tracking": {
       "id": "CVE-2024-6603",
       "initial_release_date": "2024-07-30T14:59:26Z",
-      "current_release_date": "2024-07-30T14:59:26Z",
+      "current_release_date": "2024-07-30T15:07:04Z",
       "status": "final",
-      "version": "1",
+      "version": "2",
       "revision_history": [
         {
           "date": "2024-07-30T14:59:26Z",
           "number": "1",
           "summary": "Initial version"
+        },
+        {
+          "date": "2024-07-30T15:07:04Z",
+          "number": "2",
+          "summary": "Updated version"
         }
       ]
     }
@@ -48,6 +53,14 @@
                           "name": "lts-9.2:firefox-115.13.0-3.el9_2.92ciq_lts.src",
                           "product_id": "lts-9.2:firefox-115.13.0-3.el9_2.92ciq_lts.src"
                         }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:thunderbird-115.13.0-3.el9_2.92ciq_lts.src",
+                        "product": {
+                          "name": "lts-9.2:thunderbird-115.13.0-3.el9_2.92ciq_lts.src",
+                          "product_id": "lts-9.2:thunderbird-115.13.0-3.el9_2.92ciq_lts.src"
+                        }
                       }
                     ]
                   },
@@ -62,6 +75,14 @@
                           "name": "lts-9.2:firefox-115.13.0-3.el9_2.92ciq_lts.x86_64",
                           "product_id": "lts-9.2:firefox-115.13.0-3.el9_2.92ciq_lts.x86_64"
                         }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:thunderbird-115.13.0-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:thunderbird-115.13.0-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:thunderbird-115.13.0-3.el9_2.92ciq_lts.x86_64"
+                        }
                       }
                     ]
                   },
@@ -75,6 +96,14 @@
                         "product": {
                           "name": "lts-9.2:firefox-115.13.0-3.el9_2.92ciq_lts.aarch64",
                           "product_id": "lts-9.2:firefox-115.13.0-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:thunderbird-115.13.0-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:thunderbird-115.13.0-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:thunderbird-115.13.0-3.el9_2.92ciq_lts.aarch64"
                         }
                       }
                     ]
@@ -99,8 +128,11 @@
       "product_status": {
         "fixed": [
           "lts-9.2:firefox-115.13.0-3.el9_2.92ciq_lts.src",
+          "lts-9.2:thunderbird-115.13.0-3.el9_2.92ciq_lts.src",
           "lts-9.2:firefox-115.13.0-3.el9_2.92ciq_lts.x86_64",
-          "lts-9.2:firefox-115.13.0-3.el9_2.92ciq_lts.aarch64"
+          "lts-9.2:thunderbird-115.13.0-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:firefox-115.13.0-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:thunderbird-115.13.0-3.el9_2.92ciq_lts.aarch64"
         ]
       },
       "remediations": [
@@ -109,8 +141,11 @@
           "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
           "product_ids": [
             "lts-9.2:firefox-115.13.0-3.el9_2.92ciq_lts.src",
+            "lts-9.2:thunderbird-115.13.0-3.el9_2.92ciq_lts.src",
             "lts-9.2:firefox-115.13.0-3.el9_2.92ciq_lts.x86_64",
-            "lts-9.2:firefox-115.13.0-3.el9_2.92ciq_lts.aarch64"
+            "lts-9.2:thunderbird-115.13.0-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:firefox-115.13.0-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:thunderbird-115.13.0-3.el9_2.92ciq_lts.aarch64"
           ]
         }
       ]

--- a/csaf/vex/cve/2024/cve-2024-6604.json
+++ b/csaf/vex/cve/2024/cve-2024-6604.json
@@ -11,14 +11,19 @@
     "tracking": {
       "id": "CVE-2024-6604",
       "initial_release_date": "2024-07-30T14:59:26Z",
-      "current_release_date": "2024-07-30T14:59:26Z",
+      "current_release_date": "2024-07-30T15:07:04Z",
       "status": "final",
-      "version": "1",
+      "version": "2",
       "revision_history": [
         {
           "date": "2024-07-30T14:59:26Z",
           "number": "1",
           "summary": "Initial version"
+        },
+        {
+          "date": "2024-07-30T15:07:04Z",
+          "number": "2",
+          "summary": "Updated version"
         }
       ]
     }
@@ -48,6 +53,14 @@
                           "name": "lts-9.2:firefox-115.13.0-3.el9_2.92ciq_lts.src",
                           "product_id": "lts-9.2:firefox-115.13.0-3.el9_2.92ciq_lts.src"
                         }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:thunderbird-115.13.0-3.el9_2.92ciq_lts.src",
+                        "product": {
+                          "name": "lts-9.2:thunderbird-115.13.0-3.el9_2.92ciq_lts.src",
+                          "product_id": "lts-9.2:thunderbird-115.13.0-3.el9_2.92ciq_lts.src"
+                        }
                       }
                     ]
                   },
@@ -62,6 +75,14 @@
                           "name": "lts-9.2:firefox-115.13.0-3.el9_2.92ciq_lts.x86_64",
                           "product_id": "lts-9.2:firefox-115.13.0-3.el9_2.92ciq_lts.x86_64"
                         }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:thunderbird-115.13.0-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:thunderbird-115.13.0-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:thunderbird-115.13.0-3.el9_2.92ciq_lts.x86_64"
+                        }
                       }
                     ]
                   },
@@ -75,6 +96,14 @@
                         "product": {
                           "name": "lts-9.2:firefox-115.13.0-3.el9_2.92ciq_lts.aarch64",
                           "product_id": "lts-9.2:firefox-115.13.0-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:thunderbird-115.13.0-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:thunderbird-115.13.0-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:thunderbird-115.13.0-3.el9_2.92ciq_lts.aarch64"
                         }
                       }
                     ]
@@ -99,8 +128,11 @@
       "product_status": {
         "fixed": [
           "lts-9.2:firefox-115.13.0-3.el9_2.92ciq_lts.src",
+          "lts-9.2:thunderbird-115.13.0-3.el9_2.92ciq_lts.src",
           "lts-9.2:firefox-115.13.0-3.el9_2.92ciq_lts.x86_64",
-          "lts-9.2:firefox-115.13.0-3.el9_2.92ciq_lts.aarch64"
+          "lts-9.2:thunderbird-115.13.0-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:firefox-115.13.0-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:thunderbird-115.13.0-3.el9_2.92ciq_lts.aarch64"
         ]
       },
       "remediations": [
@@ -109,8 +141,11 @@
           "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
           "product_ids": [
             "lts-9.2:firefox-115.13.0-3.el9_2.92ciq_lts.src",
+            "lts-9.2:thunderbird-115.13.0-3.el9_2.92ciq_lts.src",
             "lts-9.2:firefox-115.13.0-3.el9_2.92ciq_lts.x86_64",
-            "lts-9.2:firefox-115.13.0-3.el9_2.92ciq_lts.aarch64"
+            "lts-9.2:thunderbird-115.13.0-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:firefox-115.13.0-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:thunderbird-115.13.0-3.el9_2.92ciq_lts.aarch64"
           ]
         }
       ]


### PR DESCRIPTION
Previous commit: CVE-2024-6601, CVE-2024-6603, CVE-2024-6604 firefox LTS 92
hash c447db698395f40e5cd6acdffeb07ababd2dd32b

../../../../le-tools/csaf/csaf-ungen.sh 2024/cve-2024-6601.json > ~/tmp/CVE-2024-6601 cat >> ~/tmp/CVEs << EOF
CVE-2024-6601
thunderbird-115.13.0-3.el9_2.92ciq_lts.src.rpm
thunderbird-115.13.0-3.el9_2.92ciq_lts.x86_64
thunderbird-115.13.0-3.el9_2.92ciq_lts.aarch64
EOF

../../../../le-tools/csaf/csaf-gen.py ~/tmp/CVEs

Updated CVEs 2024-6601, 6603, 6604.

It seems okay for now. Would appreciate another look. Strangeness is that only `CVE-2024-6601` was in the input. The set of  cves (CVE-2024-6601 CVE-2024-6603 CVE-2024-6604) were all updated. (I think)

@solardiz @PlaidCat 