### PR TITLE
Fixed CVEs in FIPS-8-Compliant release kernel*4.18.0-425.13.1.el8.ciqfipscompliant.0.32*

### DIFF
--- a/csaf/vex/cve/2023/cve-2023-28464.json
+++ b/csaf/vex/cve/2023/cve-2023-28464.json
@@ -1,0 +1,409 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2023-28464",
+    "tracking": {
+      "id": "CVE-2023-28464",
+      "initial_release_date": "2024-08-05T13:59:34Z",
+      "current_release_date": "2024-08-05T13:59:34Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2024-08-05T13:59:34Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ FIPS Compliant for Rocky Linux 8",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+                          "product_id": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+                          "product_id": "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+                          "product_id": "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2023-28464",
+      "notes": [
+        {
+          "category": "description",
+          "text": "CVE-2023-28464"
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+          "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+          "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+          "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
+          "product_ids": [
+            "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+            "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+            "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+            "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2023/cve-2023-3567.json
+++ b/csaf/vex/cve/2023/cve-2023-3567.json
@@ -1,0 +1,409 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2023-3567",
+    "tracking": {
+      "id": "CVE-2023-3567",
+      "initial_release_date": "2024-08-05T13:59:34Z",
+      "current_release_date": "2024-08-05T13:59:34Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2024-08-05T13:59:34Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ FIPS Compliant for Rocky Linux 8",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+                          "product_id": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+                          "product_id": "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+                          "product_id": "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2023-3567",
+      "notes": [
+        {
+          "category": "description",
+          "text": "CVE-2023-3567"
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+          "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+          "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+          "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
+          "product_ids": [
+            "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+            "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+            "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+            "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2023/cve-2023-39198.json
+++ b/csaf/vex/cve/2023/cve-2023-39198.json
@@ -1,0 +1,409 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2023-39198",
+    "tracking": {
+      "id": "CVE-2023-39198",
+      "initial_release_date": "2024-08-05T13:59:34Z",
+      "current_release_date": "2024-08-05T13:59:34Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2024-08-05T13:59:34Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ FIPS Compliant for Rocky Linux 8",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+                          "product_id": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+                          "product_id": "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+                          "product_id": "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2023-39198",
+      "notes": [
+        {
+          "category": "description",
+          "text": "CVE-2023-39198"
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+          "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+          "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+          "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
+          "product_ids": [
+            "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+            "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+            "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+            "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2023/cve-2023-6932.json
+++ b/csaf/vex/cve/2023/cve-2023-6932.json
@@ -1,0 +1,409 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2023-6932",
+    "tracking": {
+      "id": "CVE-2023-6932",
+      "initial_release_date": "2024-08-05T13:59:34Z",
+      "current_release_date": "2024-08-05T13:59:34Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2024-08-05T13:59:34Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ FIPS Compliant for Rocky Linux 8",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+                          "product_id": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+                          "product_id": "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+                          "product_id": "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2023-6932",
+      "notes": [
+        {
+          "category": "description",
+          "text": "CVE-2023-6932"
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+          "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+          "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+          "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
+          "product_ids": [
+            "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+            "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+            "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+            "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2024/cve-2024-25742.json
+++ b/csaf/vex/cve/2024/cve-2024-25742.json
@@ -1,0 +1,409 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2024-25742",
+    "tracking": {
+      "id": "CVE-2024-25742",
+      "initial_release_date": "2024-08-05T13:59:34Z",
+      "current_release_date": "2024-08-05T13:59:34Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2024-08-05T13:59:34Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ FIPS Compliant for Rocky Linux 8",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+                          "product_id": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+                          "product_id": "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+                          "product_id": "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "product": {
+                          "name": "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2024-25742",
+      "notes": [
+        {
+          "category": "description",
+          "text": "CVE-2024-25742"
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+          "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+          "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+          "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
+          "product_ids": [
+            "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+            "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+            "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+            "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The current weekly build and release has been built and published. 
These are the CVE that are addressed in the latest version.