### PR TITLE
Fixing fipscompliant-8 product name

### DIFF
--- a/csaf/vex/cve/2019/cve-2019-15505.json
+++ b/csaf/vex/cve/2019/cve-2019-15505.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2019-15505",
       "initial_release_date": "2024-07-23T15:07:40Z",
-      "current_release_date": "2024-09-06T20:59:25Z",
+      "current_release_date": "2024-09-28T23:40:59Z",
       "status": "final",
-      "version": "2",
+      "version": "3",
       "revision_history": [
         {
           "date": "2024-07-23T15:07:40Z",
@@ -37,6 +37,11 @@
         {
           "date": "2024-09-06T20:59:25Z",
           "number": "2",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2024-09-28T23:40:59Z",
+          "number": "3",
           "summary": "Updated version"
         }
       ]

--- a/csaf/vex/cve/2019/cve-2019-15505.json
+++ b/csaf/vex/cve/2019/cve-2019-15505.json
@@ -62,10 +62,10 @@
                     "branches": [
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
                         "product": {
-                          "name": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
-                          "product_id": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src"
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src"
                         }
                       }
                     ]
@@ -76,234 +76,234 @@
                     "branches": [
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-                          "product_id": "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                          "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-                          "product_id": "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                          "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-                          "product_id": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-                          "product_id": "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                          "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-                          "product_id": "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                          "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                          "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                          "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                          "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                          "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                          "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                          "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                          "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                          "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                          "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-                          "product_id": "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                          "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-                          "product_id": "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                          "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-                          "product_id": "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                          "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-                          "product_id": "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                          "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-                          "product_id": "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                          "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-                          "product_id": "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                          "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-                          "product_id": "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                          "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-                          "product_id": "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                          "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-                          "product_id": "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                          "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-                          "product_id": "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                          "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-                          "product_id": "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                          "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-                          "product_id": "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                          "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-                          "product_id": "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                          "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-                          "product_id": "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                          "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                        "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-                          "product_id": "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+                          "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
                         }
                       }
                     ]
@@ -327,36 +327,36 @@
       ],
       "product_status": {
         "fixed": [
-          "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
-          "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-          "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-          "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-          "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-          "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-          "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-          "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-          "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-          "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-          "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-          "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-          "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-          "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-          "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-          "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-          "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-          "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-          "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-          "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-          "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-          "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-          "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-          "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-          "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-          "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-          "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-          "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-          "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-          "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+          "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+          "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
         ]
       },
       "remediations": [
@@ -364,36 +364,36 @@
           "category": "vendor_fix",
           "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
           "product_ids": [
-            "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
-            "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ],
@@ -414,36 +414,36 @@
             "version": "3.1"
           },
           "products": [
-            "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
-            "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ],
@@ -452,36 +452,36 @@
           "category": "impact",
           "details": "Moderate",
           "product_ids": [
-            "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
-            "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
-            "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.src",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.30.x86_64"
           ]
         }
       ]

--- a/csaf/vex/cve/2023/cve-2023-28464.json
+++ b/csaf/vex/cve/2023/cve-2023-28464.json
@@ -62,10 +62,10 @@
                     "branches": [
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
                         "product": {
-                          "name": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-                          "product_id": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src"
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src"
                         }
                       }
                     ]
@@ -76,18 +76,18 @@
                     "branches": [
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+                        "name": "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
                         "product": {
-                          "name": "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-                          "product_id": "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch"
+                          "name": "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+                          "product_id": "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+                        "name": "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
                         "product": {
-                          "name": "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-                          "product_id": "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch"
+                          "name": "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+                          "product_id": "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch"
                         }
                       }
                     ]
@@ -98,234 +98,234 @@
                     "branches": [
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       }
                     ]
@@ -349,38 +349,38 @@
       ],
       "product_status": {
         "fixed": [
-          "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-          "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-          "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-          "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+          "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+          "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
         ]
       },
       "remediations": [
@@ -388,38 +388,38 @@
           "category": "vendor_fix",
           "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
           "product_ids": [
-            "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-            "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+            "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+            "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
           ]
         }
       ],
@@ -440,38 +440,38 @@
             "version": "3.1"
           },
           "products": [
-            "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-            "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+            "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+            "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
           ]
         }
       ],
@@ -480,38 +480,38 @@
           "category": "impact",
           "details": "Moderate",
           "product_ids": [
-            "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-            "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+            "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+            "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
           ]
         }
       ]

--- a/csaf/vex/cve/2023/cve-2023-28464.json
+++ b/csaf/vex/cve/2023/cve-2023-28464.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-28464",
       "initial_release_date": "2024-08-05T13:59:34Z",
-      "current_release_date": "2024-09-06T20:59:25Z",
+      "current_release_date": "2024-09-28T23:40:59Z",
       "status": "final",
-      "version": "2",
+      "version": "3",
       "revision_history": [
         {
           "date": "2024-08-05T13:59:34Z",
@@ -37,6 +37,11 @@
         {
           "date": "2024-09-06T20:59:25Z",
           "number": "2",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2024-09-28T23:40:59Z",
+          "number": "3",
           "summary": "Updated version"
         }
       ]

--- a/csaf/vex/cve/2023/cve-2023-3567.json
+++ b/csaf/vex/cve/2023/cve-2023-3567.json
@@ -62,10 +62,10 @@
                     "branches": [
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
                         "product": {
-                          "name": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-                          "product_id": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src"
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src"
                         }
                       }
                     ]
@@ -76,18 +76,18 @@
                     "branches": [
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+                        "name": "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
                         "product": {
-                          "name": "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-                          "product_id": "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch"
+                          "name": "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+                          "product_id": "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+                        "name": "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
                         "product": {
-                          "name": "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-                          "product_id": "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch"
+                          "name": "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+                          "product_id": "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch"
                         }
                       }
                     ]
@@ -98,234 +98,234 @@
                     "branches": [
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       }
                     ]
@@ -349,38 +349,38 @@
       ],
       "product_status": {
         "fixed": [
-          "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-          "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-          "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-          "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+          "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+          "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
         ]
       },
       "remediations": [
@@ -388,38 +388,38 @@
           "category": "vendor_fix",
           "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
           "product_ids": [
-            "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-            "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+            "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+            "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
           ]
         }
       ],
@@ -440,38 +440,38 @@
             "version": "3.1"
           },
           "products": [
-            "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-            "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+            "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+            "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
           ]
         }
       ],
@@ -480,38 +480,38 @@
           "category": "impact",
           "details": "Moderate",
           "product_ids": [
-            "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-            "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+            "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+            "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
           ]
         }
       ]

--- a/csaf/vex/cve/2023/cve-2023-3567.json
+++ b/csaf/vex/cve/2023/cve-2023-3567.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-3567",
       "initial_release_date": "2024-08-05T13:59:34Z",
-      "current_release_date": "2024-09-06T20:59:25Z",
+      "current_release_date": "2024-09-28T23:40:59Z",
       "status": "final",
-      "version": "2",
+      "version": "3",
       "revision_history": [
         {
           "date": "2024-08-05T13:59:34Z",
@@ -37,6 +37,11 @@
         {
           "date": "2024-09-06T20:59:25Z",
           "number": "2",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2024-09-28T23:40:59Z",
+          "number": "3",
           "summary": "Updated version"
         }
       ]

--- a/csaf/vex/cve/2023/cve-2023-39198.json
+++ b/csaf/vex/cve/2023/cve-2023-39198.json
@@ -62,10 +62,10 @@
                     "branches": [
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
                         "product": {
-                          "name": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-                          "product_id": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src"
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src"
                         }
                       }
                     ]
@@ -76,18 +76,18 @@
                     "branches": [
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+                        "name": "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
                         "product": {
-                          "name": "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-                          "product_id": "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch"
+                          "name": "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+                          "product_id": "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+                        "name": "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
                         "product": {
-                          "name": "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-                          "product_id": "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch"
+                          "name": "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+                          "product_id": "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch"
                         }
                       }
                     ]
@@ -98,234 +98,234 @@
                     "branches": [
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       }
                     ]
@@ -349,38 +349,38 @@
       ],
       "product_status": {
         "fixed": [
-          "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-          "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-          "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-          "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+          "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+          "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
         ]
       },
       "remediations": [
@@ -388,38 +388,38 @@
           "category": "vendor_fix",
           "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
           "product_ids": [
-            "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-            "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+            "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+            "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
           ]
         }
       ],
@@ -440,38 +440,38 @@
             "version": "3.1"
           },
           "products": [
-            "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-            "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+            "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+            "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
           ]
         }
       ],
@@ -480,38 +480,38 @@
           "category": "impact",
           "details": "Moderate",
           "product_ids": [
-            "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-            "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+            "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+            "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
           ]
         }
       ]

--- a/csaf/vex/cve/2023/cve-2023-39198.json
+++ b/csaf/vex/cve/2023/cve-2023-39198.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-39198",
       "initial_release_date": "2024-08-05T13:59:34Z",
-      "current_release_date": "2024-09-06T20:59:25Z",
+      "current_release_date": "2024-09-28T23:40:59Z",
       "status": "final",
-      "version": "2",
+      "version": "3",
       "revision_history": [
         {
           "date": "2024-08-05T13:59:34Z",
@@ -37,6 +37,11 @@
         {
           "date": "2024-09-06T20:59:25Z",
           "number": "2",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2024-09-28T23:40:59Z",
+          "number": "3",
           "summary": "Updated version"
         }
       ]

--- a/csaf/vex/cve/2023/cve-2023-6932.json
+++ b/csaf/vex/cve/2023/cve-2023-6932.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-6932",
       "initial_release_date": "2024-08-05T13:59:34Z",
-      "current_release_date": "2024-09-06T20:59:25Z",
+      "current_release_date": "2024-09-28T23:40:59Z",
       "status": "final",
-      "version": "2",
+      "version": "3",
       "revision_history": [
         {
           "date": "2024-08-05T13:59:34Z",
@@ -37,6 +37,11 @@
         {
           "date": "2024-09-06T20:59:25Z",
           "number": "2",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2024-09-28T23:40:59Z",
+          "number": "3",
           "summary": "Updated version"
         }
       ]

--- a/csaf/vex/cve/2023/cve-2023-6932.json
+++ b/csaf/vex/cve/2023/cve-2023-6932.json
@@ -62,10 +62,10 @@
                     "branches": [
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
                         "product": {
-                          "name": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-                          "product_id": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src"
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src"
                         }
                       }
                     ]
@@ -76,18 +76,18 @@
                     "branches": [
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+                        "name": "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
                         "product": {
-                          "name": "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-                          "product_id": "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch"
+                          "name": "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+                          "product_id": "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+                        "name": "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
                         "product": {
-                          "name": "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-                          "product_id": "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch"
+                          "name": "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+                          "product_id": "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch"
                         }
                       }
                     ]
@@ -98,234 +98,234 @@
                     "branches": [
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       }
                     ]
@@ -349,38 +349,38 @@
       ],
       "product_status": {
         "fixed": [
-          "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-          "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-          "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-          "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+          "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+          "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
         ]
       },
       "remediations": [
@@ -388,38 +388,38 @@
           "category": "vendor_fix",
           "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
           "product_ids": [
-            "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-            "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+            "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+            "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
           ]
         }
       ],
@@ -440,38 +440,38 @@
             "version": "3.1"
           },
           "products": [
-            "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-            "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+            "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+            "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
           ]
         }
       ],
@@ -480,38 +480,38 @@
           "category": "impact",
           "details": "Moderate",
           "product_ids": [
-            "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-            "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+            "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+            "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
           ]
         }
       ]

--- a/csaf/vex/cve/2024/cve-2024-25742.json
+++ b/csaf/vex/cve/2024/cve-2024-25742.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2024-25742",
       "initial_release_date": "2024-08-05T13:59:34Z",
-      "current_release_date": "2024-09-06T20:59:25Z",
+      "current_release_date": "2024-09-28T23:40:59Z",
       "status": "final",
-      "version": "2",
+      "version": "3",
       "revision_history": [
         {
           "date": "2024-08-05T13:59:34Z",
@@ -37,6 +37,11 @@
         {
           "date": "2024-09-06T20:59:25Z",
           "number": "2",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2024-09-28T23:40:59Z",
+          "number": "3",
           "summary": "Updated version"
         }
       ]

--- a/csaf/vex/cve/2024/cve-2024-25742.json
+++ b/csaf/vex/cve/2024/cve-2024-25742.json
@@ -62,10 +62,10 @@
                     "branches": [
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
                         "product": {
-                          "name": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-                          "product_id": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src"
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src"
                         }
                       }
                     ]
@@ -76,18 +76,18 @@
                     "branches": [
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+                        "name": "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
                         "product": {
-                          "name": "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-                          "product_id": "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch"
+                          "name": "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+                          "product_id": "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+                        "name": "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
                         "product": {
-                          "name": "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-                          "product_id": "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch"
+                          "name": "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+                          "product_id": "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch"
                         }
                       }
                     ]
@@ -98,234 +98,234 @@
                     "branches": [
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       },
                       {
                         "category": "product_version",
-                        "name": "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                        "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
                         "product": {
-                          "name": "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+                          "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+                          "product_id": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
                         }
                       }
                     ]
@@ -349,38 +349,38 @@
       ],
       "product_status": {
         "fixed": [
-          "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-          "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-          "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-          "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+          "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+          "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+          "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
         ]
       },
       "remediations": [
@@ -388,38 +388,38 @@
           "category": "vendor_fix",
           "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
           "product_ids": [
-            "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-            "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+            "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+            "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
           ]
         }
       ],
@@ -440,38 +440,38 @@
             "version": "3.1"
           },
           "products": [
-            "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-            "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+            "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+            "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
           ]
         }
       ],
@@ -480,38 +480,38 @@
           "category": "impact",
           "details": "Moderate",
           "product_ids": [
-            "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-            "fipscompliant-8:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fipscompliant-8:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fipscompliant-8:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fipscompliant-8:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
+            "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+            "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
           ]
         }
       ]


### PR DESCRIPTION
Should be "fips-8-compliant" , matching the Mountain v2 interface