### PR TITLE
CVE-2023-48161 java-1.8.0-openjdk java-11-openjdk java-17-openjdk LTS 8.6

### DIFF
--- a/csaf/vex/cve/2023/cve-2023-48161.json
+++ b/csaf/vex/cve/2023/cve-2023-48161.json
@@ -1,0 +1,8882 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability severity score data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2023-48161",
+    "tracking": {
+      "id": "CVE-2023-48161",
+      "initial_release_date": "2024-10-23T11:42:38Z",
+      "current_release_date": "2024-10-23T14:40:16Z",
+      "status": "final",
+      "version": "4",
+      "revision_history": [
+        {
+          "date": "2024-10-23T11:42:38Z",
+          "number": "1",
+          "summary": "Initial version"
+        },
+        {
+          "date": "2024-10-23T13:32:34Z",
+          "number": "2",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2024-10-23T13:39:31Z",
+          "number": "3",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2024-10-23T14:40:16Z",
+          "number": "4",
+          "summary": "Updated version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 9.2",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+                          "product_id": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+                          "product_id": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.8",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+                          "product_id": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+                          "product_id": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2023-48161",
+      "notes": [
+        {
+          "category": "description",
+          "text": "CVE-2023-48161"
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+          "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+          "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+          "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+          "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+          "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+          "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+          "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+          "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+          "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+          "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+          "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+          "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+          "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+          "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
+          "product_ids": [
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 7.1,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2024/cve-2024-21131.json
+++ b/csaf/vex/cve/2024/cve-2024-21131.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2024-21131",
       "initial_release_date": "2024-09-29T02:05:22Z",
-      "current_release_date": "2024-10-15T18:55:12Z",
+      "current_release_date": "2024-10-23T14:40:16Z",
       "status": "final",
-      "version": "2",
+      "version": "5",
       "revision_history": [
         {
           "date": "2024-09-29T02:05:22Z",
@@ -37,6 +37,21 @@
         {
           "date": "2024-10-15T18:55:12Z",
           "number": "2",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2024-10-23T14:28:43Z",
+          "number": "3",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2024-10-23T14:29:07Z",
+          "number": "4",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2024-10-23T14:40:16Z",
+          "number": "5",
           "summary": "Updated version"
         }
       ]
@@ -669,6 +684,5882 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 9.2",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+                          "product_id": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+                          "product_id": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.8",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+                          "product_id": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+                          "product_id": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -758,7 +6649,728 @@
           "cbr-7.9:java-11-openjdk-src-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
           "cbr-7.9:java-11-openjdk-src-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
           "cbr-7.9:java-11-openjdk-static-libs-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
-          "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64"
+          "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
+          "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+          "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+          "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+          "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+          "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+          "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+          "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+          "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+          "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+          "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+          "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+          "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+          "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+          "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+          "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
         ]
       },
       "remediations": [
@@ -837,7 +7449,728 @@
             "cbr-7.9:java-11-openjdk-src-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
             "cbr-7.9:java-11-openjdk-src-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
             "cbr-7.9:java-11-openjdk-static-libs-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
-            "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64"
+            "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
           ]
         }
       ],
@@ -929,7 +8262,728 @@
             "cbr-7.9:java-11-openjdk-src-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
             "cbr-7.9:java-11-openjdk-src-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
             "cbr-7.9:java-11-openjdk-static-libs-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
-            "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64"
+            "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
           ]
         }
       ],
@@ -1009,7 +9063,728 @@
             "cbr-7.9:java-11-openjdk-src-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
             "cbr-7.9:java-11-openjdk-src-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
             "cbr-7.9:java-11-openjdk-static-libs-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
-            "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64"
+            "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
           ]
         }
       ]

--- a/csaf/vex/cve/2024/cve-2024-21138.json
+++ b/csaf/vex/cve/2024/cve-2024-21138.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2024-21138",
       "initial_release_date": "2024-09-29T02:05:22Z",
-      "current_release_date": "2024-10-15T18:55:12Z",
+      "current_release_date": "2024-10-23T14:40:16Z",
       "status": "final",
-      "version": "2",
+      "version": "5",
       "revision_history": [
         {
           "date": "2024-09-29T02:05:22Z",
@@ -37,6 +37,21 @@
         {
           "date": "2024-10-15T18:55:12Z",
           "number": "2",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2024-10-23T14:28:43Z",
+          "number": "3",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2024-10-23T14:29:07Z",
+          "number": "4",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2024-10-23T14:40:16Z",
+          "number": "5",
           "summary": "Updated version"
         }
       ]
@@ -669,6 +684,5882 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 9.2",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+                          "product_id": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+                          "product_id": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.8",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+                          "product_id": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+                          "product_id": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -758,7 +6649,728 @@
           "cbr-7.9:java-11-openjdk-src-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
           "cbr-7.9:java-11-openjdk-src-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
           "cbr-7.9:java-11-openjdk-static-libs-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
-          "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64"
+          "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
+          "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+          "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+          "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+          "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+          "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+          "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+          "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+          "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+          "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+          "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+          "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+          "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+          "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+          "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+          "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
         ]
       },
       "remediations": [
@@ -837,7 +7449,728 @@
             "cbr-7.9:java-11-openjdk-src-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
             "cbr-7.9:java-11-openjdk-src-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
             "cbr-7.9:java-11-openjdk-static-libs-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
-            "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64"
+            "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
           ]
         }
       ],
@@ -929,7 +8262,728 @@
             "cbr-7.9:java-11-openjdk-src-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
             "cbr-7.9:java-11-openjdk-src-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
             "cbr-7.9:java-11-openjdk-static-libs-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
-            "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64"
+            "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
           ]
         }
       ],
@@ -1009,7 +9063,728 @@
             "cbr-7.9:java-11-openjdk-src-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
             "cbr-7.9:java-11-openjdk-src-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
             "cbr-7.9:java-11-openjdk-static-libs-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
-            "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64"
+            "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
           ]
         }
       ]

--- a/csaf/vex/cve/2024/cve-2024-21140.json
+++ b/csaf/vex/cve/2024/cve-2024-21140.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2024-21140",
       "initial_release_date": "2024-09-29T02:05:22Z",
-      "current_release_date": "2024-10-15T18:55:12Z",
+      "current_release_date": "2024-10-23T14:40:16Z",
       "status": "final",
-      "version": "2",
+      "version": "5",
       "revision_history": [
         {
           "date": "2024-09-29T02:05:22Z",
@@ -37,6 +37,21 @@
         {
           "date": "2024-10-15T18:55:12Z",
           "number": "2",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2024-10-23T14:28:43Z",
+          "number": "3",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2024-10-23T14:29:07Z",
+          "number": "4",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2024-10-23T14:40:16Z",
+          "number": "5",
           "summary": "Updated version"
         }
       ]
@@ -669,6 +684,5882 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 9.2",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+                          "product_id": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+                          "product_id": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.8",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+                          "product_id": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+                          "product_id": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -758,7 +6649,728 @@
           "cbr-7.9:java-11-openjdk-src-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
           "cbr-7.9:java-11-openjdk-src-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
           "cbr-7.9:java-11-openjdk-static-libs-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
-          "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64"
+          "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
+          "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+          "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+          "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+          "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+          "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+          "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+          "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+          "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+          "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+          "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+          "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+          "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+          "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+          "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+          "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
         ]
       },
       "remediations": [
@@ -837,7 +7449,728 @@
             "cbr-7.9:java-11-openjdk-src-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
             "cbr-7.9:java-11-openjdk-src-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
             "cbr-7.9:java-11-openjdk-static-libs-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
-            "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64"
+            "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
           ]
         }
       ],
@@ -929,7 +8262,728 @@
             "cbr-7.9:java-11-openjdk-src-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
             "cbr-7.9:java-11-openjdk-src-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
             "cbr-7.9:java-11-openjdk-static-libs-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
-            "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64"
+            "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
           ]
         }
       ],
@@ -1009,7 +9063,728 @@
             "cbr-7.9:java-11-openjdk-src-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
             "cbr-7.9:java-11-openjdk-src-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
             "cbr-7.9:java-11-openjdk-static-libs-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
-            "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64"
+            "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
           ]
         }
       ]

--- a/csaf/vex/cve/2024/cve-2024-21144.json
+++ b/csaf/vex/cve/2024/cve-2024-21144.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2024-21144",
       "initial_release_date": "2024-09-29T02:05:22Z",
-      "current_release_date": "2024-10-15T18:55:12Z",
+      "current_release_date": "2024-10-23T14:40:16Z",
       "status": "final",
-      "version": "2",
+      "version": "5",
       "revision_history": [
         {
           "date": "2024-09-29T02:05:22Z",
@@ -37,6 +37,21 @@
         {
           "date": "2024-10-15T18:55:12Z",
           "number": "2",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2024-10-23T14:28:43Z",
+          "number": "3",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2024-10-23T14:29:07Z",
+          "number": "4",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2024-10-23T14:40:16Z",
+          "number": "5",
           "summary": "Updated version"
         }
       ]
@@ -669,6 +684,5882 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 9.2",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+                          "product_id": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+                          "product_id": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.8",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+                          "product_id": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+                          "product_id": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -758,7 +6649,728 @@
           "cbr-7.9:java-11-openjdk-src-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
           "cbr-7.9:java-11-openjdk-src-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
           "cbr-7.9:java-11-openjdk-static-libs-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
-          "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64"
+          "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
+          "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+          "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+          "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+          "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+          "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+          "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+          "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+          "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+          "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+          "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+          "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+          "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+          "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+          "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+          "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
         ]
       },
       "remediations": [
@@ -837,7 +7449,728 @@
             "cbr-7.9:java-11-openjdk-src-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
             "cbr-7.9:java-11-openjdk-src-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
             "cbr-7.9:java-11-openjdk-static-libs-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
-            "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64"
+            "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
           ]
         }
       ],
@@ -929,7 +8262,728 @@
             "cbr-7.9:java-11-openjdk-src-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
             "cbr-7.9:java-11-openjdk-src-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
             "cbr-7.9:java-11-openjdk-static-libs-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
-            "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64"
+            "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
           ]
         }
       ],
@@ -1009,7 +9063,728 @@
             "cbr-7.9:java-11-openjdk-src-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
             "cbr-7.9:java-11-openjdk-src-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
             "cbr-7.9:java-11-openjdk-static-libs-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
-            "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64"
+            "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
           ]
         }
       ]

--- a/csaf/vex/cve/2024/cve-2024-21145.json
+++ b/csaf/vex/cve/2024/cve-2024-21145.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2024-21145",
       "initial_release_date": "2024-09-29T02:05:22Z",
-      "current_release_date": "2024-10-15T18:55:12Z",
+      "current_release_date": "2024-10-23T14:40:16Z",
       "status": "final",
-      "version": "2",
+      "version": "5",
       "revision_history": [
         {
           "date": "2024-09-29T02:05:22Z",
@@ -37,6 +37,21 @@
         {
           "date": "2024-10-15T18:55:12Z",
           "number": "2",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2024-10-23T14:28:43Z",
+          "number": "3",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2024-10-23T14:29:07Z",
+          "number": "4",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2024-10-23T14:40:16Z",
+          "number": "5",
           "summary": "Updated version"
         }
       ]
@@ -669,6 +684,5882 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 9.2",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+                          "product_id": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+                          "product_id": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.8",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+                          "product_id": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+                          "product_id": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -758,7 +6649,728 @@
           "cbr-7.9:java-11-openjdk-src-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
           "cbr-7.9:java-11-openjdk-src-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
           "cbr-7.9:java-11-openjdk-static-libs-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
-          "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64"
+          "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
+          "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+          "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+          "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+          "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+          "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+          "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+          "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+          "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+          "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+          "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+          "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+          "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+          "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+          "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+          "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
         ]
       },
       "remediations": [
@@ -837,7 +7449,728 @@
             "cbr-7.9:java-11-openjdk-src-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
             "cbr-7.9:java-11-openjdk-src-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
             "cbr-7.9:java-11-openjdk-static-libs-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
-            "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64"
+            "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
           ]
         }
       ],
@@ -929,7 +8262,728 @@
             "cbr-7.9:java-11-openjdk-src-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
             "cbr-7.9:java-11-openjdk-src-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
             "cbr-7.9:java-11-openjdk-static-libs-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
-            "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64"
+            "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
           ]
         }
       ],
@@ -1009,7 +9063,728 @@
             "cbr-7.9:java-11-openjdk-src-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
             "cbr-7.9:java-11-openjdk-src-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
             "cbr-7.9:java-11-openjdk-static-libs-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
-            "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64"
+            "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
           ]
         }
       ]

--- a/csaf/vex/cve/2024/cve-2024-21147.json
+++ b/csaf/vex/cve/2024/cve-2024-21147.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2024-21147",
       "initial_release_date": "2024-09-29T02:05:22Z",
-      "current_release_date": "2024-10-15T18:55:12Z",
+      "current_release_date": "2024-10-23T14:40:16Z",
       "status": "final",
-      "version": "2",
+      "version": "5",
       "revision_history": [
         {
           "date": "2024-09-29T02:05:22Z",
@@ -37,6 +37,21 @@
         {
           "date": "2024-10-15T18:55:12Z",
           "number": "2",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2024-10-23T14:28:43Z",
+          "number": "3",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2024-10-23T14:29:07Z",
+          "number": "4",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2024-10-23T14:40:16Z",
+          "number": "5",
           "summary": "Updated version"
         }
       ]
@@ -669,6 +684,5882 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 9.2",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+                          "product_id": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+                          "product_id": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.8",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+                          "product_id": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+                          "product_id": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -758,7 +6649,728 @@
           "cbr-7.9:java-11-openjdk-src-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
           "cbr-7.9:java-11-openjdk-src-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
           "cbr-7.9:java-11-openjdk-static-libs-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
-          "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64"
+          "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
+          "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+          "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+          "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+          "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+          "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+          "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+          "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+          "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+          "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+          "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+          "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+          "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+          "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+          "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+          "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
         ]
       },
       "remediations": [
@@ -837,7 +7449,728 @@
             "cbr-7.9:java-11-openjdk-src-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
             "cbr-7.9:java-11-openjdk-src-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
             "cbr-7.9:java-11-openjdk-static-libs-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
-            "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64"
+            "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
           ]
         }
       ],
@@ -929,7 +8262,728 @@
             "cbr-7.9:java-11-openjdk-src-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
             "cbr-7.9:java-11-openjdk-src-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
             "cbr-7.9:java-11-openjdk-static-libs-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
-            "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64"
+            "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
           ]
         }
       ],
@@ -1009,7 +9063,728 @@
             "cbr-7.9:java-11-openjdk-src-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
             "cbr-7.9:java-11-openjdk-src-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
             "cbr-7.9:java-11-openjdk-static-libs-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
-            "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64"
+            "cbr-7.9:java-11-openjdk-static-libs-debug-11.0.23.0.9-2.0.3.el7_9.ciqcbr.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
           ]
         }
       ]

--- a/csaf/vex/cve/2024/cve-2024-21208.json
+++ b/csaf/vex/cve/2024/cve-2024-21208.json
@@ -1,0 +1,8882 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability severity score data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2024-21208",
+    "tracking": {
+      "id": "CVE-2024-21208",
+      "initial_release_date": "2024-10-23T11:42:38Z",
+      "current_release_date": "2024-10-23T14:40:16Z",
+      "status": "final",
+      "version": "4",
+      "revision_history": [
+        {
+          "date": "2024-10-23T11:42:38Z",
+          "number": "1",
+          "summary": "Initial version"
+        },
+        {
+          "date": "2024-10-23T13:32:34Z",
+          "number": "2",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2024-10-23T13:39:31Z",
+          "number": "3",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2024-10-23T14:40:16Z",
+          "number": "4",
+          "summary": "Updated version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 9.2",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+                          "product_id": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+                          "product_id": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.8",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+                          "product_id": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+                          "product_id": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2024-21208",
+      "notes": [
+        {
+          "category": "description",
+          "text": "CVE-2024-21208"
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+          "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+          "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+          "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+          "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+          "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+          "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+          "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+          "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+          "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+          "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+          "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+          "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+          "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+          "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
+          "product_ids": [
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "HIGH",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "LOW",
+            "baseScore": 3.7,
+            "baseSeverity": "LOW",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:L",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2024/cve-2024-21210.json
+++ b/csaf/vex/cve/2024/cve-2024-21210.json
@@ -1,0 +1,8882 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability severity score data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2024-21210",
+    "tracking": {
+      "id": "CVE-2024-21210",
+      "initial_release_date": "2024-10-23T11:42:38Z",
+      "current_release_date": "2024-10-23T14:40:16Z",
+      "status": "final",
+      "version": "4",
+      "revision_history": [
+        {
+          "date": "2024-10-23T11:42:38Z",
+          "number": "1",
+          "summary": "Initial version"
+        },
+        {
+          "date": "2024-10-23T13:32:34Z",
+          "number": "2",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2024-10-23T13:39:31Z",
+          "number": "3",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2024-10-23T14:40:16Z",
+          "number": "4",
+          "summary": "Updated version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 9.2",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+                          "product_id": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+                          "product_id": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.8",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+                          "product_id": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+                          "product_id": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2024-21210",
+      "notes": [
+        {
+          "category": "description",
+          "text": "CVE-2024-21210"
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+          "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+          "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+          "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+          "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+          "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+          "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+          "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+          "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+          "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+          "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+          "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+          "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+          "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+          "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
+          "product_ids": [
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "HIGH",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 3.7,
+            "baseSeverity": "LOW",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "LOW",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2024/cve-2024-21217.json
+++ b/csaf/vex/cve/2024/cve-2024-21217.json
@@ -1,0 +1,8882 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability severity score data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2024-21217",
+    "tracking": {
+      "id": "CVE-2024-21217",
+      "initial_release_date": "2024-10-23T11:42:38Z",
+      "current_release_date": "2024-10-23T14:40:16Z",
+      "status": "final",
+      "version": "4",
+      "revision_history": [
+        {
+          "date": "2024-10-23T11:42:38Z",
+          "number": "1",
+          "summary": "Initial version"
+        },
+        {
+          "date": "2024-10-23T13:32:34Z",
+          "number": "2",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2024-10-23T13:39:31Z",
+          "number": "3",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2024-10-23T14:40:16Z",
+          "number": "4",
+          "summary": "Updated version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 9.2",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+                          "product_id": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+                          "product_id": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.8",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+                          "product_id": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+                          "product_id": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2024-21217",
+      "notes": [
+        {
+          "category": "description",
+          "text": "CVE-2024-21217"
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+          "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+          "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+          "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+          "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+          "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+          "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+          "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+          "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+          "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+          "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+          "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+          "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+          "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+          "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
+          "product_ids": [
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "HIGH",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "LOW",
+            "baseScore": 3.7,
+            "baseSeverity": "LOW",
+            "confidentialityImpact": "NONE",
+            "integrityImpact": "NONE",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:L",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2024/cve-2024-21235.json
+++ b/csaf/vex/cve/2024/cve-2024-21235.json
@@ -1,0 +1,8882 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability severity score data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2024-21235",
+    "tracking": {
+      "id": "CVE-2024-21235",
+      "initial_release_date": "2024-10-23T11:42:38Z",
+      "current_release_date": "2024-10-23T14:40:16Z",
+      "status": "final",
+      "version": "4",
+      "revision_history": [
+        {
+          "date": "2024-10-23T11:42:38Z",
+          "number": "1",
+          "summary": "Initial version"
+        },
+        {
+          "date": "2024-10-23T13:32:34Z",
+          "number": "2",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2024-10-23T13:39:31Z",
+          "number": "3",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2024-10-23T14:40:16Z",
+          "number": "4",
+          "summary": "Updated version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+                          "product_id": "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+                          "product_id": "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+                          "product_id": "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 9.2",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+                        "product": {
+                          "name": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+                          "product_id": "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+                        "product": {
+                          "name": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+                          "product_id": "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+                        "product": {
+                          "name": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+                          "product_id": "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.8",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "i686",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+                          "product_id": "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+                          "product_id": "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src",
+                        "product": {
+                          "name": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src",
+                          "product_id": "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2024-21235",
+      "notes": [
+        {
+          "category": "description",
+          "text": "CVE-2024-21235"
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+          "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+          "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+          "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+          "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+          "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+          "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+          "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+          "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+          "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+          "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+          "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+          "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+          "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+          "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+          "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+          "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+          "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+          "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+          "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+          "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+          "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+          "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+          "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
+          "product_ids": [
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "HIGH",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "NONE",
+            "baseScore": 4.8,
+            "baseSeverity": "MEDIUM",
+            "confidentialityImpact": "LOW",
+            "integrityImpact": "LOW",
+            "privilegesRequired": "NONE",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Moderate",
+          "product_ids": [
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_6.86ciq_lts.noarch",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.aarch64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_6.86ciq_lts.i686",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_6.86ciq_lts.x86_64",
+            "lts-8.6:java-11-openjdk-11.0.25.0.9-2.el8_6.86ciq_lts.src",
+            "lts-8.6:java-17-openjdk-17.0.13.0.11-3.el8_6.86ciq_lts.src",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.aarch64",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.i686",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-debugsource-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-debugsource-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el9_2.92ciq_lts.x86_64",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el9_2.92ciq_lts.noarch",
+            "lts-9.2:java-11-openjdk-11.0.25.0.9-2.el9_2.92ciq_lts.src",
+            "lts-9.2:java-17-openjdk-17.0.13.0.11-3.el9_2.92ciq_lts.src",
+            "lts-9.2:java-1.8.0-openjdk-1.8.0.432.b06-2.el9_2.92ciq_lts.src",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.aarch64",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.i686",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-debugsource-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-demo-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-devel-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-fastdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-headless-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-javadoc-zip-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-jmods-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-slowdebug-debuginfo-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-src-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-fastdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-11-openjdk-static-libs-slowdebug-11.0.25.0.9-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-debugsource-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-demo-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-devel-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-fastdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-headless-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-javadoc-zip-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-jmods-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-slowdebug-debuginfo-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-src-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-fastdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-17-openjdk-static-libs-slowdebug-17.0.13.0.11-3.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-accessibility-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-debugsource-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-demo-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-devel-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-fastdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-headless-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-slowdebug-debuginfo-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-fastdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-src-slowdebug-1.8.0.432.b06-2.el8_8.88ciq_lts.x86_64",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-1.8.0-openjdk-javadoc-zip-1.8.0.432.b06-2.el8_8.88ciq_lts.noarch",
+            "lts-8.8:java-11-openjdk-11.0.25.0.9-2.el8_8.88ciq_lts.src",
+            "lts-8.8:java-17-openjdk-17.0.13.0.11-3.el8_8.88ciq_lts.src",
+            "lts-8.8:java-1.8.0-openjdk-1.8.0.432.b06-2.el8_8.88ciq_lts.src"
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This contains the following CVE fixes in LTS 8.6, LTS 8.8 and LTS 9.2:
CVE-2023-48161 - 7.1
CVE-2024-21131 - 3.7
CVE-2024-21138 - 3.7
CVE-2024-21140 - 4.8
CVE-2024-21144 - 3.7
CVE-2024-21145 - 4.8
CVE-2024-21147 - 7.4
CVE-2024-21208 - 3.7
CVE-2024-21210 - 3.7
CVE-2024-21217 - 3.7
CVE-2024-21235 - 4.8


For the following packages
java-1.8.0-openjdk
java-11-openjdk
java-17-openjdk