### PR TITLE
[LTS 8.6] Add CVEs fixed prior to CSAF project

### DIFF
--- a/csaf/vex/cve/2022/cve-2022-1679.json
+++ b/csaf/vex/cve/2022/cve-2022-1679.json
@@ -21,38 +21,18 @@
       "name": "CIQ",
       "namespace": "https://www.ciq.com"
     },
-    "title": "CIQ Security Advisory: Remediation of CVE-2023-3567",
+    "title": "CIQ Security Advisory: Remediation of CVE-2022-1679",
     "tracking": {
-      "id": "CVE-2023-3567",
-      "initial_release_date": "2024-08-05T13:59:34Z",
-      "current_release_date": "2025-09-05T22:05:41Z",
+      "id": "CVE-2022-1679",
+      "initial_release_date": "2025-09-05T22:05:43Z",
+      "current_release_date": "2025-09-05T22:05:43Z",
       "status": "final",
-      "version": "5",
+      "version": "1",
       "revision_history": [
         {
-          "date": "2024-08-05T13:59:34Z",
+          "date": "2025-09-05T22:05:43Z",
           "number": "1",
           "summary": "Initial version"
-        },
-        {
-          "date": "2024-09-06T20:59:25Z",
-          "number": "2",
-          "summary": "Updated version"
-        },
-        {
-          "date": "2024-09-28T23:40:59Z",
-          "number": "3",
-          "summary": "Updated version"
-        },
-        {
-          "date": "2025-06-04T20:19:16Z",
-          "number": "4",
-          "summary": "Updated version"
-        },
-        {
-          "date": "2025-09-05T22:05:41Z",
-          "number": "5",
-          "summary": "Updated version"
         }
       ]
     }
@@ -67,286 +47,6 @@
             "category": "product_family",
             "name": "CIQ LTS for Rocky Linux and CentOS",
             "branches": [
-              {
-                "category": "product_name",
-                "name": "CIQ FIPS Compliant for Rocky Linux 8 (legacy)",
-                "branches": [
-                  {
-                    "category": "architecture",
-                    "name": "src",
-                    "branches": [
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "category": "architecture",
-                    "name": "noarch",
-                    "branches": [
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-                          "product_id": "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-                          "product_id": "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "category": "architecture",
-                    "name": "x86_64",
-                    "branches": [
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      }
-                    ]
-                  }
-                ]
-              },
               {
                 "category": "product_name",
                 "name": "CIQ LTS for Rocky Linux 8.6",
@@ -865,47 +565,15 @@
   },
   "vulnerabilities": [
     {
-      "cve": "CVE-2023-3567",
+      "cve": "CVE-2022-1679",
       "notes": [
         {
           "category": "description",
-          "text": "A use-after-free flaw was found in vcs_read in drivers/tty/vt/vc_screen.c in vc_screen in the Linux Kernel. This issue may allow an attacker with local user access to cause a system crash or leak internal kernel information."
+          "text": "A use-after-free flaw was found in the Linux kernel\u2019s Atheros wireless adapter driver in the way a user forces the ath9k_htc_wait_for_target function to fail with some input messages. This flaw allows a local user to crash or potentially escalate their privileges on the system."
         }
       ],
       "product_status": {
         "fixed": [
-          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-          "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-          "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
           "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
           "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
           "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
@@ -973,38 +641,6 @@
           "category": "vendor_fix",
           "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
           "product_ids": [
-            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-            "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
             "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
             "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
@@ -1071,52 +707,20 @@
       "scores": [
         {
           "cvss_v3": {
-            "attackComplexity": "LOW",
+            "attackComplexity": "HIGH",
             "attackVector": "LOCAL",
             "availabilityImpact": "HIGH",
-            "baseScore": 7.1,
+            "baseScore": 7.0,
             "baseSeverity": "HIGH",
             "confidentialityImpact": "HIGH",
-            "integrityImpact": "NONE",
+            "integrityImpact": "HIGH",
             "privilegesRequired": "LOW",
             "scope": "UNCHANGED",
             "userInteraction": "NONE",
-            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:H",
+            "vectorString": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H",
             "version": "3.1"
           },
           "products": [
-            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-            "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
             "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
             "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
@@ -1185,38 +789,6 @@
           "category": "impact",
           "details": "Moderate",
           "product_ids": [
-            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-            "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
             "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
             "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",

--- a/csaf/vex/cve/2022/cve-2022-20141.json
+++ b/csaf/vex/cve/2022/cve-2022-20141.json
@@ -21,38 +21,18 @@
       "name": "CIQ",
       "namespace": "https://www.ciq.com"
     },
-    "title": "CIQ Security Advisory: Remediation of CVE-2023-3567",
+    "title": "CIQ Security Advisory: Remediation of CVE-2022-20141",
     "tracking": {
-      "id": "CVE-2023-3567",
-      "initial_release_date": "2024-08-05T13:59:34Z",
-      "current_release_date": "2025-09-05T22:05:41Z",
+      "id": "CVE-2022-20141",
+      "initial_release_date": "2025-09-05T22:05:43Z",
+      "current_release_date": "2025-09-05T22:05:43Z",
       "status": "final",
-      "version": "5",
+      "version": "1",
       "revision_history": [
         {
-          "date": "2024-08-05T13:59:34Z",
+          "date": "2025-09-05T22:05:43Z",
           "number": "1",
           "summary": "Initial version"
-        },
-        {
-          "date": "2024-09-06T20:59:25Z",
-          "number": "2",
-          "summary": "Updated version"
-        },
-        {
-          "date": "2024-09-28T23:40:59Z",
-          "number": "3",
-          "summary": "Updated version"
-        },
-        {
-          "date": "2025-06-04T20:19:16Z",
-          "number": "4",
-          "summary": "Updated version"
-        },
-        {
-          "date": "2025-09-05T22:05:41Z",
-          "number": "5",
-          "summary": "Updated version"
         }
       ]
     }
@@ -67,286 +47,6 @@
             "category": "product_family",
             "name": "CIQ LTS for Rocky Linux and CentOS",
             "branches": [
-              {
-                "category": "product_name",
-                "name": "CIQ FIPS Compliant for Rocky Linux 8 (legacy)",
-                "branches": [
-                  {
-                    "category": "architecture",
-                    "name": "src",
-                    "branches": [
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "category": "architecture",
-                    "name": "noarch",
-                    "branches": [
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-                          "product_id": "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-                          "product_id": "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "category": "architecture",
-                    "name": "x86_64",
-                    "branches": [
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      }
-                    ]
-                  }
-                ]
-              },
               {
                 "category": "product_name",
                 "name": "CIQ LTS for Rocky Linux 8.6",
@@ -865,47 +565,15 @@
   },
   "vulnerabilities": [
     {
-      "cve": "CVE-2023-3567",
+      "cve": "CVE-2022-20141",
       "notes": [
         {
           "category": "description",
-          "text": "A use-after-free flaw was found in vcs_read in drivers/tty/vt/vc_screen.c in vc_screen in the Linux Kernel. This issue may allow an attacker with local user access to cause a system crash or leak internal kernel information."
+          "text": "A use-after-free flaw was found in the Linux kernel\u2019s IGMP protocol in how a user triggers a race condition in the ip_check_mc_rcu function. This flaw allows a local user to crash or potentially escalate their privileges on the system."
         }
       ],
       "product_status": {
         "fixed": [
-          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-          "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-          "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
           "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
           "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
           "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
@@ -973,38 +641,6 @@
           "category": "vendor_fix",
           "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
           "product_ids": [
-            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-            "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
             "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
             "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
@@ -1071,52 +707,20 @@
       "scores": [
         {
           "cvss_v3": {
-            "attackComplexity": "LOW",
+            "attackComplexity": "HIGH",
             "attackVector": "LOCAL",
             "availabilityImpact": "HIGH",
-            "baseScore": 7.1,
+            "baseScore": 7.0,
             "baseSeverity": "HIGH",
             "confidentialityImpact": "HIGH",
-            "integrityImpact": "NONE",
+            "integrityImpact": "HIGH",
             "privilegesRequired": "LOW",
             "scope": "UNCHANGED",
             "userInteraction": "NONE",
-            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:H",
+            "vectorString": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H",
             "version": "3.1"
           },
           "products": [
-            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-            "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
             "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
             "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
@@ -1185,38 +789,6 @@
           "category": "impact",
           "details": "Moderate",
           "product_ids": [
-            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-            "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
             "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
             "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",

--- a/csaf/vex/cve/2022/cve-2022-4139.json
+++ b/csaf/vex/cve/2022/cve-2022-4139.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2022-4139",
       "initial_release_date": "2024-08-14T19:41:55Z",
-      "current_release_date": "2025-06-04T20:19:16Z",
+      "current_release_date": "2025-09-05T22:05:41Z",
       "status": "final",
-      "version": "3",
+      "version": "4",
       "revision_history": [
         {
           "date": "2024-08-14T19:41:55Z",
@@ -42,6 +42,11 @@
         {
           "date": "2025-06-04T20:19:16Z",
           "number": "3",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-05T22:05:41Z",
+          "number": "4",
           "summary": "Updated version"
         }
       ]
@@ -71,6 +76,14 @@
                         "product": {
                           "name": "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
                           "product_id": "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src"
                         }
                       }
                     ]
@@ -222,6 +235,490 @@
                           "name": "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
                           "product_id": "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64"
                         }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
                       }
                     ]
                   }
@@ -245,6 +742,7 @@
       "product_status": {
         "fixed": [
           "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
           "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -262,7 +760,66 @@
           "lts-8.6:kernel-rt-modules-extra-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
-          "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64"
+          "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
         ]
       },
       "remediations": [
@@ -271,6 +828,7 @@
           "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
           "product_ids": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -288,7 +846,66 @@
             "lts-8.6:kernel-rt-modules-extra-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
-            "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64"
+            "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
           ]
         }
       ],
@@ -310,6 +927,7 @@
           },
           "products": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -327,7 +945,66 @@
             "lts-8.6:kernel-rt-modules-extra-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
-            "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64"
+            "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
           ]
         }
       ],
@@ -337,6 +1014,7 @@
           "details": "Important",
           "product_ids": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -354,7 +1032,66 @@
             "lts-8.6:kernel-rt-modules-extra-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
-            "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64"
+            "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
           ]
         }
       ]

--- a/csaf/vex/cve/2022/cve-2022-41858.json
+++ b/csaf/vex/cve/2022/cve-2022-41858.json
@@ -21,38 +21,18 @@
       "name": "CIQ",
       "namespace": "https://www.ciq.com"
     },
-    "title": "CIQ Security Advisory: Remediation of CVE-2023-3567",
+    "title": "CIQ Security Advisory: Remediation of CVE-2022-41858",
     "tracking": {
-      "id": "CVE-2023-3567",
-      "initial_release_date": "2024-08-05T13:59:34Z",
-      "current_release_date": "2025-09-05T22:05:41Z",
+      "id": "CVE-2022-41858",
+      "initial_release_date": "2025-09-05T22:05:43Z",
+      "current_release_date": "2025-09-05T22:05:43Z",
       "status": "final",
-      "version": "5",
+      "version": "1",
       "revision_history": [
         {
-          "date": "2024-08-05T13:59:34Z",
+          "date": "2025-09-05T22:05:43Z",
           "number": "1",
           "summary": "Initial version"
-        },
-        {
-          "date": "2024-09-06T20:59:25Z",
-          "number": "2",
-          "summary": "Updated version"
-        },
-        {
-          "date": "2024-09-28T23:40:59Z",
-          "number": "3",
-          "summary": "Updated version"
-        },
-        {
-          "date": "2025-06-04T20:19:16Z",
-          "number": "4",
-          "summary": "Updated version"
-        },
-        {
-          "date": "2025-09-05T22:05:41Z",
-          "number": "5",
-          "summary": "Updated version"
         }
       ]
     }
@@ -67,286 +47,6 @@
             "category": "product_family",
             "name": "CIQ LTS for Rocky Linux and CentOS",
             "branches": [
-              {
-                "category": "product_name",
-                "name": "CIQ FIPS Compliant for Rocky Linux 8 (legacy)",
-                "branches": [
-                  {
-                    "category": "architecture",
-                    "name": "src",
-                    "branches": [
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "category": "architecture",
-                    "name": "noarch",
-                    "branches": [
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-                          "product_id": "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-                          "product_id": "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "category": "architecture",
-                    "name": "x86_64",
-                    "branches": [
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      }
-                    ]
-                  }
-                ]
-              },
               {
                 "category": "product_name",
                 "name": "CIQ LTS for Rocky Linux 8.6",
@@ -865,47 +565,15 @@
   },
   "vulnerabilities": [
     {
-      "cve": "CVE-2023-3567",
+      "cve": "CVE-2022-41858",
       "notes": [
         {
           "category": "description",
-          "text": "A use-after-free flaw was found in vcs_read in drivers/tty/vt/vc_screen.c in vc_screen in the Linux Kernel. This issue may allow an attacker with local user access to cause a system crash or leak internal kernel information."
+          "text": "A flaw was found in the Linux kernel. A NULL pointer dereference may occur while a slip driver is in progress to detach in sl_tx_timeout in drivers/net/slip/slip.c. This issue could allow an attacker to crash the system or leak internal kernel information."
         }
       ],
       "product_status": {
         "fixed": [
-          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-          "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-          "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
           "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
           "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
           "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
@@ -973,38 +641,6 @@
           "category": "vendor_fix",
           "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
           "product_ids": [
-            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-            "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
             "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
             "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
@@ -1085,38 +721,6 @@
             "version": "3.1"
           },
           "products": [
-            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-            "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
             "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
             "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
@@ -1185,38 +789,6 @@
           "category": "impact",
           "details": "Moderate",
           "product_ids": [
-            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-            "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
             "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
             "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",

--- a/csaf/vex/cve/2023/cve-2023-0386.json
+++ b/csaf/vex/cve/2023/cve-2023-0386.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-0386",
       "initial_release_date": "2024-08-14T19:41:55Z",
-      "current_release_date": "2025-06-04T20:19:16Z",
+      "current_release_date": "2025-09-05T21:45:34Z",
       "status": "final",
-      "version": "3",
+      "version": "4",
       "revision_history": [
         {
           "date": "2024-08-14T19:41:55Z",
@@ -42,6 +42,11 @@
         {
           "date": "2025-06-04T20:19:16Z",
           "number": "3",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-05T21:45:34Z",
+          "number": "4",
           "summary": "Updated version"
         }
       ]
@@ -71,6 +76,14 @@
                         "product": {
                           "name": "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
                           "product_id": "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src"
                         }
                       }
                     ]
@@ -222,6 +235,490 @@
                           "name": "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
                           "product_id": "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64"
                         }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
                       }
                     ]
                   }
@@ -245,6 +742,7 @@
       "product_status": {
         "fixed": [
           "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
           "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -262,7 +760,66 @@
           "lts-8.6:kernel-rt-modules-extra-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
-          "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64"
+          "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
         ]
       },
       "remediations": [
@@ -271,6 +828,7 @@
           "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
           "product_ids": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -288,7 +846,66 @@
             "lts-8.6:kernel-rt-modules-extra-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
-            "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64"
+            "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
           ]
         }
       ],
@@ -310,6 +927,7 @@
           },
           "products": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -327,7 +945,66 @@
             "lts-8.6:kernel-rt-modules-extra-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
-            "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64"
+            "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
           ]
         }
       ],
@@ -337,6 +1014,7 @@
           "details": "Important",
           "product_ids": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -354,7 +1032,66 @@
             "lts-8.6:kernel-rt-modules-extra-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
-            "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64"
+            "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
           ]
         }
       ]

--- a/csaf/vex/cve/2023/cve-2023-1281.json
+++ b/csaf/vex/cve/2023/cve-2023-1281.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-1281",
       "initial_release_date": "2024-08-14T19:41:55Z",
-      "current_release_date": "2025-07-29T21:13:46Z",
+      "current_release_date": "2025-09-05T21:45:34Z",
       "status": "final",
-      "version": "4",
+      "version": "5",
       "revision_history": [
         {
           "date": "2024-08-14T19:41:55Z",
@@ -47,6 +47,11 @@
         {
           "date": "2025-07-29T21:13:46Z",
           "number": "4",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-05T21:45:34Z",
+          "number": "5",
           "summary": "Updated version"
         }
       ]
@@ -76,6 +81,14 @@
                         "product": {
                           "name": "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
                           "product_id": "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src"
                         }
                       }
                     ]
@@ -227,6 +240,490 @@
                           "name": "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
                           "product_id": "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64"
                         }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
                       }
                     ]
                   }
@@ -246,20 +743,6 @@
                         "product": {
                           "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.src",
                           "product_id": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.src"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "category": "architecture",
-                    "name": "i686",
-                    "branches": [
-                      {
-                        "category": "product_version",
-                        "name": "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.i686",
-                        "product": {
-                          "name": "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.i686",
-                          "product_id": "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.i686"
                         }
                       }
                     ]
@@ -456,6 +939,7 @@
       "product_status": {
         "fixed": [
           "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
           "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -474,8 +958,66 @@
           "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
           "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.src",
-          "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.i686",
           "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.x86_64",
           "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.x86_64",
           "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.x86_64",
@@ -504,6 +1046,7 @@
           "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
           "product_ids": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -522,8 +1065,66 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.src",
-            "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.i686",
             "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.x86_64",
             "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.x86_64",
             "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.x86_64",
@@ -565,6 +1166,7 @@
           },
           "products": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -583,8 +1185,66 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.src",
-            "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.i686",
             "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.x86_64",
             "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.x86_64",
             "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.x86_64",
@@ -614,6 +1274,7 @@
           "details": "Important",
           "product_ids": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -632,8 +1293,66 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.src",
-            "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.i686",
             "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.x86_64",
             "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.x86_64",
             "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.x86_64",

--- a/csaf/vex/cve/2023/cve-2023-1829.json
+++ b/csaf/vex/cve/2023/cve-2023-1829.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-1829",
       "initial_release_date": "2024-08-14T19:41:55Z",
-      "current_release_date": "2025-07-29T21:13:46Z",
+      "current_release_date": "2025-09-05T21:45:34Z",
       "status": "final",
-      "version": "4",
+      "version": "5",
       "revision_history": [
         {
           "date": "2024-08-14T19:41:55Z",
@@ -47,6 +47,11 @@
         {
           "date": "2025-07-29T21:13:46Z",
           "number": "4",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-05T21:45:34Z",
+          "number": "5",
           "summary": "Updated version"
         }
       ]
@@ -76,6 +81,14 @@
                         "product": {
                           "name": "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
                           "product_id": "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src"
                         }
                       }
                     ]
@@ -227,6 +240,490 @@
                           "name": "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
                           "product_id": "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64"
                         }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
                       }
                     ]
                   }
@@ -246,20 +743,6 @@
                         "product": {
                           "name": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.src",
                           "product_id": "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.src"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "category": "architecture",
-                    "name": "i686",
-                    "branches": [
-                      {
-                        "category": "product_version",
-                        "name": "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.i686",
-                        "product": {
-                          "name": "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.i686",
-                          "product_id": "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.i686"
                         }
                       }
                     ]
@@ -456,6 +939,7 @@
       "product_status": {
         "fixed": [
           "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
           "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -474,8 +958,66 @@
           "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
           "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.src",
-          "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.i686",
           "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.x86_64",
           "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.x86_64",
           "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.x86_64",
@@ -504,6 +1046,7 @@
           "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
           "product_ids": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -522,8 +1065,66 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.src",
-            "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.i686",
             "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.x86_64",
             "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.x86_64",
             "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.x86_64",
@@ -565,6 +1166,7 @@
           },
           "products": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -583,8 +1185,66 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.src",
-            "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.i686",
             "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.x86_64",
             "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.x86_64",
             "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.x86_64",
@@ -614,6 +1274,7 @@
           "details": "Important",
           "product_ids": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -632,8 +1293,66 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.src",
-            "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.i686",
             "cbr-7.9:kernel-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.x86_64",
             "cbr-7.9:kernel-headers-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.x86_64",
             "cbr-7.9:kernel-debuginfo-common-x86_64-3.10.0-1160.119.1.el7_9.ciqcbr.6.1.x86_64",

--- a/csaf/vex/cve/2023/cve-2023-1838.json
+++ b/csaf/vex/cve/2023/cve-2023-1838.json
@@ -21,38 +21,18 @@
       "name": "CIQ",
       "namespace": "https://www.ciq.com"
     },
-    "title": "CIQ Security Advisory: Remediation of CVE-2023-3567",
+    "title": "CIQ Security Advisory: Remediation of CVE-2023-1838",
     "tracking": {
-      "id": "CVE-2023-3567",
-      "initial_release_date": "2024-08-05T13:59:34Z",
-      "current_release_date": "2025-09-05T22:05:41Z",
+      "id": "CVE-2023-1838",
+      "initial_release_date": "2025-09-05T22:05:43Z",
+      "current_release_date": "2025-09-05T22:05:43Z",
       "status": "final",
-      "version": "5",
+      "version": "1",
       "revision_history": [
         {
-          "date": "2024-08-05T13:59:34Z",
+          "date": "2025-09-05T22:05:43Z",
           "number": "1",
           "summary": "Initial version"
-        },
-        {
-          "date": "2024-09-06T20:59:25Z",
-          "number": "2",
-          "summary": "Updated version"
-        },
-        {
-          "date": "2024-09-28T23:40:59Z",
-          "number": "3",
-          "summary": "Updated version"
-        },
-        {
-          "date": "2025-06-04T20:19:16Z",
-          "number": "4",
-          "summary": "Updated version"
-        },
-        {
-          "date": "2025-09-05T22:05:41Z",
-          "number": "5",
-          "summary": "Updated version"
         }
       ]
     }
@@ -67,286 +47,6 @@
             "category": "product_family",
             "name": "CIQ LTS for Rocky Linux and CentOS",
             "branches": [
-              {
-                "category": "product_name",
-                "name": "CIQ FIPS Compliant for Rocky Linux 8 (legacy)",
-                "branches": [
-                  {
-                    "category": "architecture",
-                    "name": "src",
-                    "branches": [
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "category": "architecture",
-                    "name": "noarch",
-                    "branches": [
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-                          "product_id": "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-                          "product_id": "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "category": "architecture",
-                    "name": "x86_64",
-                    "branches": [
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      }
-                    ]
-                  }
-                ]
-              },
               {
                 "category": "product_name",
                 "name": "CIQ LTS for Rocky Linux 8.6",
@@ -865,47 +565,15 @@
   },
   "vulnerabilities": [
     {
-      "cve": "CVE-2023-3567",
+      "cve": "CVE-2023-1838",
       "notes": [
         {
           "category": "description",
-          "text": "A use-after-free flaw was found in vcs_read in drivers/tty/vt/vc_screen.c in vc_screen in the Linux Kernel. This issue may allow an attacker with local user access to cause a system crash or leak internal kernel information."
+          "text": "A use-after-free flaw was found in vhost_net_set_backend in drivers/vhost/net.c in the virtio network subcomponent in the Linux kernel due to a double fget. This issue could allow a local attacker to crash the system, and could lead to a kernel information leak problem."
         }
       ],
       "product_status": {
         "fixed": [
-          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-          "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-          "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
           "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
           "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
           "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
@@ -973,38 +641,6 @@
           "category": "vendor_fix",
           "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
           "product_ids": [
-            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-            "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
             "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
             "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
@@ -1085,38 +721,6 @@
             "version": "3.1"
           },
           "products": [
-            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-            "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
             "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
             "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
@@ -1185,38 +789,6 @@
           "category": "impact",
           "details": "Moderate",
           "product_ids": [
-            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-            "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
             "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
             "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",

--- a/csaf/vex/cve/2023/cve-2023-2124.json
+++ b/csaf/vex/cve/2023/cve-2023-2124.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-2124",
       "initial_release_date": "2024-08-14T19:41:55Z",
-      "current_release_date": "2025-06-04T20:19:16Z",
+      "current_release_date": "2025-09-05T21:45:35Z",
       "status": "final",
-      "version": "3",
+      "version": "4",
       "revision_history": [
         {
           "date": "2024-08-14T19:41:55Z",
@@ -42,6 +42,11 @@
         {
           "date": "2025-06-04T20:19:16Z",
           "number": "3",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-05T21:45:35Z",
+          "number": "4",
           "summary": "Updated version"
         }
       ]
@@ -71,6 +76,14 @@
                         "product": {
                           "name": "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
                           "product_id": "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src"
                         }
                       }
                     ]
@@ -222,6 +235,490 @@
                           "name": "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
                           "product_id": "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64"
                         }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
                       }
                     ]
                   }
@@ -245,6 +742,7 @@
       "product_status": {
         "fixed": [
           "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
           "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -262,7 +760,66 @@
           "lts-8.6:kernel-rt-modules-extra-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
-          "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64"
+          "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
         ]
       },
       "remediations": [
@@ -271,6 +828,7 @@
           "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
           "product_ids": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -288,7 +846,66 @@
             "lts-8.6:kernel-rt-modules-extra-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
-            "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64"
+            "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
           ]
         }
       ],
@@ -310,6 +927,7 @@
           },
           "products": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -327,7 +945,66 @@
             "lts-8.6:kernel-rt-modules-extra-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
-            "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64"
+            "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
           ]
         }
       ],
@@ -337,6 +1014,7 @@
           "details": "Moderate",
           "product_ids": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -354,7 +1032,66 @@
             "lts-8.6:kernel-rt-modules-extra-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
-            "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64"
+            "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
           ]
         }
       ]

--- a/csaf/vex/cve/2023/cve-2023-2163.json
+++ b/csaf/vex/cve/2023/cve-2023-2163.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-2163",
       "initial_release_date": "2024-12-12T23:24:06Z",
-      "current_release_date": "2025-06-04T20:19:16Z",
+      "current_release_date": "2025-09-05T22:05:41Z",
       "status": "final",
-      "version": "6",
+      "version": "7",
       "revision_history": [
         {
           "date": "2024-12-12T23:24:06Z",
@@ -57,6 +57,11 @@
         {
           "date": "2025-06-04T20:19:16Z",
           "number": "6",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-05T22:05:41Z",
+          "number": "7",
           "summary": "Updated version"
         }
       ]
@@ -94,28 +99,6 @@
                         "product": {
                           "name": "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.src",
                           "product_id": "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.src"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "category": "architecture",
-                    "name": "i686",
-                    "branches": [
-                      {
-                        "category": "product_version",
-                        "name": "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.i686",
-                        "product": {
-                          "name": "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.i686",
-                          "product_id": "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.i686"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.i686",
-                        "product": {
-                          "name": "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.i686",
-                          "product_id": "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.i686"
                         }
                       }
                     ]
@@ -1120,28 +1103,6 @@
                   },
                   {
                     "category": "architecture",
-                    "name": "i686",
-                    "branches": [
-                      {
-                        "category": "product_version",
-                        "name": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.3.1.i686",
-                        "product": {
-                          "name": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.3.1.i686",
-                          "product_id": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.3.1.i686"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.3.1.i686",
-                        "product": {
-                          "name": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.3.1.i686",
-                          "product_id": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.3.1.i686"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "category": "architecture",
                     "name": "noarch",
                     "branches": [
                       {
@@ -1791,6 +1752,14 @@
                           "name": "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.src",
                           "product_id": "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.src"
                         }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src"
+                        }
                       }
                     ]
                   },
@@ -1941,6 +1910,490 @@
                           "name": "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
                           "product_id": "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64"
                         }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
                       }
                     ]
                   }
@@ -1964,8 +2417,7 @@
       "product_status": {
         "fixed": [
           "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.src",
-          "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.i686",
-          "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.i686",
+          "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.src",
           "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.noarch",
           "lts-9.2:kernel-doc-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.noarch",
           "lts-9.2:kernel-debug-devel-matched-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.x86_64",
@@ -2006,6 +2458,30 @@
           "lts-9.2:kernel-uki-virt-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.x86_64",
           "lts-9.2:kernel-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.x86_64",
           "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.x86_64",
+          "lts-9.2:kernel-rt-debug-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debug-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debug-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debug-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debug-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debug-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-selftests-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debug-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debug-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debuginfo-common-x86_64-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debug-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debug-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debug-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
           "lts-9.2:kernel-64k-devel-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
           "lts-9.2:kernel-64k-debug-devel-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
           "lts-9.2:kernel-selftests-internal-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
@@ -2062,8 +2538,7 @@
           "lts-9.2:kernel-64k-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
           "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
           "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.3.1.src",
-          "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.3.1.i686",
-          "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.3.1.i686",
+          "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.src",
           "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.3.1.noarch",
           "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.3.1.noarch",
           "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.3.1.aarch64",
@@ -2123,32 +2598,26 @@
           "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.3.1.x86_64",
           "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.3.1.x86_64",
           "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.3.1.x86_64",
-          "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.src",
-          "lts-9.2:kernel-rt-debug-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debug-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debug-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debug-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debug-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debug-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-selftests-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debug-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debug-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debuginfo-common-x86_64-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debug-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debug-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debug-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-debuginfo-common-x86_64-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-selftests-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-debug-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-debug-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-debug-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-debug-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-debug-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-debug-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-debug-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-debug-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
           "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.src",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
           "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
           "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
           "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
@@ -2167,25 +2636,65 @@
           "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
           "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
           "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
-          "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.src",
-          "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-debuginfo-common-x86_64-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-selftests-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-debug-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-debug-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-debug-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-debug-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-debug-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-debug-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-debug-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-debug-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64"
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
         ]
       },
       "remediations": [
@@ -2194,8 +2703,7 @@
           "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
           "product_ids": [
             "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.src",
-            "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.i686",
-            "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.i686",
+            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.src",
             "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.noarch",
             "lts-9.2:kernel-doc-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.noarch",
             "lts-9.2:kernel-debug-devel-matched-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.x86_64",
@@ -2236,6 +2744,30 @@
             "lts-9.2:kernel-uki-virt-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.x86_64",
             "lts-9.2:kernel-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.x86_64",
             "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.x86_64",
+            "lts-9.2:kernel-rt-debug-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-selftests-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debuginfo-common-x86_64-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
             "lts-9.2:kernel-64k-devel-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
             "lts-9.2:kernel-64k-debug-devel-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
             "lts-9.2:kernel-selftests-internal-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
@@ -2292,8 +2824,7 @@
             "lts-9.2:kernel-64k-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
             "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.3.1.src",
-            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.3.1.i686",
-            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.3.1.i686",
+            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.src",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.3.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.3.1.noarch",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.3.1.aarch64",
@@ -2353,32 +2884,26 @@
             "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.3.1.x86_64",
             "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.3.1.x86_64",
             "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.3.1.x86_64",
-            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.src",
-            "lts-9.2:kernel-rt-debug-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-selftests-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debuginfo-common-x86_64-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debuginfo-common-x86_64-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-selftests-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
@@ -2397,25 +2922,65 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
-            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.src",
-            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debuginfo-common-x86_64-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-selftests-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64"
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
           ]
         }
       ],
@@ -2437,8 +3002,7 @@
           },
           "products": [
             "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.src",
-            "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.i686",
-            "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.i686",
+            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.src",
             "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.noarch",
             "lts-9.2:kernel-doc-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.noarch",
             "lts-9.2:kernel-debug-devel-matched-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.x86_64",
@@ -2479,6 +3043,30 @@
             "lts-9.2:kernel-uki-virt-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.x86_64",
             "lts-9.2:kernel-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.x86_64",
             "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.x86_64",
+            "lts-9.2:kernel-rt-debug-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-selftests-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debuginfo-common-x86_64-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
             "lts-9.2:kernel-64k-devel-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
             "lts-9.2:kernel-64k-debug-devel-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
             "lts-9.2:kernel-selftests-internal-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
@@ -2535,8 +3123,7 @@
             "lts-9.2:kernel-64k-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
             "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.3.1.src",
-            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.3.1.i686",
-            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.3.1.i686",
+            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.src",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.3.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.3.1.noarch",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.3.1.aarch64",
@@ -2596,32 +3183,26 @@
             "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.3.1.x86_64",
             "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.3.1.x86_64",
             "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.3.1.x86_64",
-            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.src",
-            "lts-9.2:kernel-rt-debug-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-selftests-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debuginfo-common-x86_64-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debuginfo-common-x86_64-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-selftests-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
@@ -2640,25 +3221,65 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
-            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.src",
-            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debuginfo-common-x86_64-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-selftests-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64"
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
           ]
         }
       ],
@@ -2668,8 +3289,7 @@
           "details": "Important",
           "product_ids": [
             "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.src",
-            "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.i686",
-            "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.i686",
+            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.src",
             "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.noarch",
             "lts-9.2:kernel-doc-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.noarch",
             "lts-9.2:kernel-debug-devel-matched-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.x86_64",
@@ -2710,6 +3330,30 @@
             "lts-9.2:kernel-uki-virt-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.x86_64",
             "lts-9.2:kernel-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.x86_64",
             "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.x86_64",
+            "lts-9.2:kernel-rt-debug-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-selftests-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debuginfo-common-x86_64-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
             "lts-9.2:kernel-64k-devel-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
             "lts-9.2:kernel-64k-debug-devel-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
             "lts-9.2:kernel-selftests-internal-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
@@ -2766,8 +3410,7 @@
             "lts-9.2:kernel-64k-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
             "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.3.1.src",
-            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.3.1.i686",
-            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.3.1.i686",
+            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.src",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.3.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.3.1.noarch",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.3.1.aarch64",
@@ -2827,32 +3470,26 @@
             "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.3.1.x86_64",
             "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.3.1.x86_64",
             "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.3.1.x86_64",
-            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.src",
-            "lts-9.2:kernel-rt-debug-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-selftests-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debuginfo-common-x86_64-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debuginfo-common-x86_64-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-selftests-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
@@ -2871,25 +3508,65 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
-            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.src",
-            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debuginfo-common-x86_64-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-selftests-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64"
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
           ]
         }
       ]

--- a/csaf/vex/cve/2023/cve-2023-2235.json
+++ b/csaf/vex/cve/2023/cve-2023-2235.json
@@ -1,0 +1,857 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2023-2235",
+    "tracking": {
+      "id": "CVE-2023-2235",
+      "initial_release_date": "2025-09-05T21:45:36Z",
+      "current_release_date": "2025-09-05T21:45:36Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2025-09-05T21:45:36Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2023-2235",
+      "notes": [
+        {
+          "category": "description",
+          "text": "The Linux kernel's Performance Events subsystem has a use-after-free flaw that occurs when a user triggers the perf_group_detach and remove_on_exec functions simultaneously. This flaw allows a local user to crash or potentially escalate their privileges on the system."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
+          "product_ids": [
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 7.8,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Important",
+          "product_ids": [
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2023/cve-2023-2513.json
+++ b/csaf/vex/cve/2023/cve-2023-2513.json
@@ -21,38 +21,18 @@
       "name": "CIQ",
       "namespace": "https://www.ciq.com"
     },
-    "title": "CIQ Security Advisory: Remediation of CVE-2023-3567",
+    "title": "CIQ Security Advisory: Remediation of CVE-2023-2513",
     "tracking": {
-      "id": "CVE-2023-3567",
-      "initial_release_date": "2024-08-05T13:59:34Z",
-      "current_release_date": "2025-09-05T22:05:41Z",
+      "id": "CVE-2023-2513",
+      "initial_release_date": "2025-09-05T22:05:43Z",
+      "current_release_date": "2025-09-05T22:05:43Z",
       "status": "final",
-      "version": "5",
+      "version": "1",
       "revision_history": [
         {
-          "date": "2024-08-05T13:59:34Z",
+          "date": "2025-09-05T22:05:43Z",
           "number": "1",
           "summary": "Initial version"
-        },
-        {
-          "date": "2024-09-06T20:59:25Z",
-          "number": "2",
-          "summary": "Updated version"
-        },
-        {
-          "date": "2024-09-28T23:40:59Z",
-          "number": "3",
-          "summary": "Updated version"
-        },
-        {
-          "date": "2025-06-04T20:19:16Z",
-          "number": "4",
-          "summary": "Updated version"
-        },
-        {
-          "date": "2025-09-05T22:05:41Z",
-          "number": "5",
-          "summary": "Updated version"
         }
       ]
     }
@@ -67,286 +47,6 @@
             "category": "product_family",
             "name": "CIQ LTS for Rocky Linux and CentOS",
             "branches": [
-              {
-                "category": "product_name",
-                "name": "CIQ FIPS Compliant for Rocky Linux 8 (legacy)",
-                "branches": [
-                  {
-                    "category": "architecture",
-                    "name": "src",
-                    "branches": [
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "category": "architecture",
-                    "name": "noarch",
-                    "branches": [
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-                          "product_id": "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-                          "product_id": "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "category": "architecture",
-                    "name": "x86_64",
-                    "branches": [
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                        "product": {
-                          "name": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-                          "product_id": "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64"
-                        }
-                      }
-                    ]
-                  }
-                ]
-              },
               {
                 "category": "product_name",
                 "name": "CIQ LTS for Rocky Linux 8.6",
@@ -865,47 +565,15 @@
   },
   "vulnerabilities": [
     {
-      "cve": "CVE-2023-3567",
+      "cve": "CVE-2023-2513",
       "notes": [
         {
           "category": "description",
-          "text": "A use-after-free flaw was found in vcs_read in drivers/tty/vt/vc_screen.c in vc_screen in the Linux Kernel. This issue may allow an attacker with local user access to cause a system crash or leak internal kernel information."
+          "text": "A use-after-free vulnerability was found in the Linux kernel's ext4 filesystem in the way it handled the extra inode size for extended attributes. This flaw allows a privileged local user to cause a system crash or other undefined behaviors."
         }
       ],
       "product_status": {
         "fixed": [
-          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-          "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-          "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-          "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
           "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
           "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
           "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
@@ -973,38 +641,6 @@
           "category": "vendor_fix",
           "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
           "product_ids": [
-            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-            "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
             "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
             "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
@@ -1071,52 +707,20 @@
       "scores": [
         {
           "cvss_v3": {
-            "attackComplexity": "LOW",
+            "attackComplexity": "HIGH",
             "attackVector": "LOCAL",
             "availabilityImpact": "HIGH",
-            "baseScore": 7.1,
+            "baseScore": 7.0,
             "baseSeverity": "HIGH",
             "confidentialityImpact": "HIGH",
-            "integrityImpact": "NONE",
+            "integrityImpact": "HIGH",
             "privilegesRequired": "LOW",
             "scope": "UNCHANGED",
             "userInteraction": "NONE",
-            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:H",
+            "vectorString": "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H",
             "version": "3.1"
           },
           "products": [
-            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-            "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
             "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
             "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
@@ -1185,38 +789,6 @@
           "category": "impact",
           "details": "Moderate",
           "product_ids": [
-            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.src",
-            "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.noarch",
-            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
-            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.0.32.x86_64",
             "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
             "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
             "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",

--- a/csaf/vex/cve/2023/cve-2023-28466.json
+++ b/csaf/vex/cve/2023/cve-2023-28466.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-28466",
       "initial_release_date": "2024-08-14T19:41:55Z",
-      "current_release_date": "2025-06-04T20:19:16Z",
+      "current_release_date": "2025-09-05T21:45:35Z",
       "status": "final",
-      "version": "3",
+      "version": "4",
       "revision_history": [
         {
           "date": "2024-08-14T19:41:55Z",
@@ -42,6 +42,11 @@
         {
           "date": "2025-06-04T20:19:16Z",
           "number": "3",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-05T21:45:35Z",
+          "number": "4",
           "summary": "Updated version"
         }
       ]
@@ -71,6 +76,14 @@
                         "product": {
                           "name": "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
                           "product_id": "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src"
                         }
                       }
                     ]
@@ -222,6 +235,490 @@
                           "name": "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
                           "product_id": "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64"
                         }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
                       }
                     ]
                   }
@@ -245,6 +742,7 @@
       "product_status": {
         "fixed": [
           "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
           "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -262,7 +760,66 @@
           "lts-8.6:kernel-rt-modules-extra-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
-          "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64"
+          "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
         ]
       },
       "remediations": [
@@ -271,6 +828,7 @@
           "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
           "product_ids": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -288,7 +846,66 @@
             "lts-8.6:kernel-rt-modules-extra-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
-            "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64"
+            "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
           ]
         }
       ],
@@ -310,6 +927,7 @@
           },
           "products": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -327,7 +945,66 @@
             "lts-8.6:kernel-rt-modules-extra-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
-            "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64"
+            "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
           ]
         }
       ],
@@ -337,6 +1014,7 @@
           "details": "Moderate",
           "product_ids": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -354,7 +1032,66 @@
             "lts-8.6:kernel-rt-modules-extra-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
-            "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64"
+            "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
           ]
         }
       ]

--- a/csaf/vex/cve/2023/cve-2023-3090.json
+++ b/csaf/vex/cve/2023/cve-2023-3090.json
@@ -1,0 +1,857 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2023-3090",
+    "tracking": {
+      "id": "CVE-2023-3090",
+      "initial_release_date": "2025-09-05T21:45:36Z",
+      "current_release_date": "2025-09-05T21:45:36Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2025-09-05T21:45:36Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2023-3090",
+      "notes": [
+        {
+          "category": "description",
+          "text": "A flaw was found in the IPVLAN network driver in the Linux kernel. This issue is caused by missing skb->cb initialization in `__ip_options_echo` and can lead to an out-of-bounds write stack overflow. This may allow a local user to cause a denial of service or potentially achieve local privilege escalation."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
+          "product_ids": [
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 7.8,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Important",
+          "product_ids": [
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2023/cve-2023-31436.json
+++ b/csaf/vex/cve/2023/cve-2023-31436.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-31436",
       "initial_release_date": "2025-06-09T14:44:07Z",
-      "current_release_date": "2025-07-14T22:17:03Z",
+      "current_release_date": "2025-09-05T22:05:41Z",
       "status": "final",
-      "version": "4",
+      "version": "5",
       "revision_history": [
         {
           "date": "2025-06-09T14:44:07Z",
@@ -47,6 +47,11 @@
         {
           "date": "2025-07-14T22:17:03Z",
           "number": "4",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-05T22:05:41Z",
+          "number": "5",
           "summary": "Updated version"
         }
       ]
@@ -612,28 +617,6 @@
                         "product": {
                           "name": "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.src",
                           "product_id": "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.src"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "category": "architecture",
-                    "name": "i686",
-                    "branches": [
-                      {
-                        "category": "product_version",
-                        "name": "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.i686",
-                        "product": {
-                          "name": "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.i686",
-                          "product_id": "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.i686"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.i686",
-                        "product": {
-                          "name": "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.i686",
-                          "product_id": "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.i686"
                         }
                       }
                     ]
@@ -1438,28 +1421,6 @@
                   },
                   {
                     "category": "architecture",
-                    "name": "i686",
-                    "branches": [
-                      {
-                        "category": "product_version",
-                        "name": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-                        "product": {
-                          "name": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-                          "product_id": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-                        "product": {
-                          "name": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-                          "product_id": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "category": "architecture",
                     "name": "noarch",
                     "branches": [
                       {
@@ -1949,6 +1910,516 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -1968,8 +2439,11 @@
       "product_status": {
         "fixed": [
           "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.40.1.src",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.src",
           "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.40.1.noarch",
           "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.40.1.noarch",
+          "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.noarch",
+          "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.noarch",
           "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.40.1.x86_64",
           "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.40.1.x86_64",
           "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.40.1.x86_64",
@@ -1999,9 +2473,36 @@
           "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.40.1.x86_64",
           "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.40.1.x86_64",
           "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.40.1.x86_64",
+          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+          "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+          "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+          "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+          "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+          "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+          "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+          "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+          "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+          "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+          "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+          "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+          "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+          "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+          "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+          "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+          "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+          "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+          "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+          "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+          "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+          "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+          "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+          "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+          "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+          "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+          "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+          "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+          "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
           "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.src",
-          "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.i686",
-          "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.i686",
           "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.noarch",
           "lts-9.2:kernel-doc-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.noarch",
           "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.x86_64",
@@ -2097,41 +2598,7 @@
           "lts-9.2:kernel-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.aarch64",
           "lts-9.2:kernel-64k-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.aarch64",
           "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.aarch64",
-          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.src",
-          "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.noarch",
-          "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.noarch",
-          "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-          "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-          "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-          "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-          "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-          "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-          "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-          "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-          "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-          "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-          "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-          "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-          "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-          "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-          "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-          "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-          "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-          "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-          "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-          "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-          "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-          "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-          "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-          "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-          "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-          "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-          "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-          "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-          "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
           "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.src",
-          "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-          "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
           "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
           "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
           "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.aarch64",
@@ -2190,7 +2657,67 @@
           "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
           "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
           "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-          "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64"
+          "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
         ]
       },
       "remediations": [
@@ -2199,8 +2726,11 @@
           "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
           "product_ids": [
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.40.1.src",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.src",
             "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.40.1.noarch",
             "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.40.1.noarch",
+            "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.noarch",
+            "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.noarch",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.40.1.x86_64",
             "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.40.1.x86_64",
             "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.40.1.x86_64",
@@ -2230,9 +2760,36 @@
             "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.40.1.x86_64",
             "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.40.1.x86_64",
             "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.40.1.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
             "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.src",
-            "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.i686",
-            "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.i686",
             "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.noarch",
             "lts-9.2:kernel-doc-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.noarch",
             "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.x86_64",
@@ -2328,41 +2885,7 @@
             "lts-9.2:kernel-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.aarch64",
             "lts-9.2:kernel-64k-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.aarch64",
             "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.aarch64",
-            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.src",
-            "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.noarch",
-            "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.noarch",
-            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.src",
-            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.aarch64",
@@ -2421,7 +2944,67 @@
             "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
             "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
             "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64"
+            "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
           ]
         }
       ],
@@ -2443,8 +3026,11 @@
           },
           "products": [
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.40.1.src",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.src",
             "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.40.1.noarch",
             "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.40.1.noarch",
+            "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.noarch",
+            "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.noarch",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.40.1.x86_64",
             "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.40.1.x86_64",
             "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.40.1.x86_64",
@@ -2474,9 +3060,36 @@
             "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.40.1.x86_64",
             "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.40.1.x86_64",
             "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.40.1.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
             "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.src",
-            "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.i686",
-            "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.i686",
             "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.noarch",
             "lts-9.2:kernel-doc-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.noarch",
             "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.x86_64",
@@ -2572,41 +3185,7 @@
             "lts-9.2:kernel-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.aarch64",
             "lts-9.2:kernel-64k-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.aarch64",
             "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.aarch64",
-            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.src",
-            "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.noarch",
-            "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.noarch",
-            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.src",
-            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.aarch64",
@@ -2665,7 +3244,67 @@
             "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
             "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
             "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64"
+            "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
           ]
         }
       ],
@@ -2675,8 +3314,11 @@
           "details": "Important",
           "product_ids": [
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.40.1.src",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.src",
             "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.40.1.noarch",
             "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.40.1.noarch",
+            "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.noarch",
+            "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.noarch",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.40.1.x86_64",
             "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.40.1.x86_64",
             "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.40.1.x86_64",
@@ -2706,9 +3348,36 @@
             "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.40.1.x86_64",
             "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.40.1.x86_64",
             "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.40.1.x86_64",
+            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
+            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
             "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.src",
-            "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.i686",
-            "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.i686",
             "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.noarch",
             "lts-9.2:kernel-doc-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.noarch",
             "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.x86_64",
@@ -2804,41 +3473,7 @@
             "lts-9.2:kernel-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.aarch64",
             "lts-9.2:kernel-64k-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.aarch64",
             "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.aarch64",
-            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.src",
-            "fips-8-compliant:kernel-doc-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.noarch",
-            "fips-8-compliant:kernel-abi-stablelists-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.noarch",
-            "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-headers-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-cross-headers-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-debuginfo-common-x86_64-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:perf-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:python3-perf-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-tools-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-tools-libs-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-tools-libs-devel-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-tools-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-selftests-internal-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-debug-core-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-debug-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-debug-devel-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-debug-modules-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-debug-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-debug-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-debug-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-core-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-devel-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-modules-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-modules-extra-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-modules-internal-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
-            "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.src",
-            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.aarch64",
@@ -2897,7 +3532,67 @@
             "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
             "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
             "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64"
+            "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
           ]
         }
       ]

--- a/csaf/vex/cve/2023/cve-2023-32233.json
+++ b/csaf/vex/cve/2023/cve-2023-32233.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-32233",
       "initial_release_date": "2024-08-14T19:41:55Z",
-      "current_release_date": "2025-06-04T20:19:16Z",
+      "current_release_date": "2025-09-05T21:45:35Z",
       "status": "final",
-      "version": "4",
+      "version": "5",
       "revision_history": [
         {
           "date": "2024-08-14T19:41:55Z",
@@ -47,6 +47,11 @@
         {
           "date": "2025-06-04T20:19:16Z",
           "number": "4",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-05T21:45:35Z",
+          "number": "5",
           "summary": "Updated version"
         }
       ]
@@ -76,6 +81,14 @@
                         "product": {
                           "name": "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
                           "product_id": "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src"
                         }
                       }
                     ]
@@ -226,6 +239,490 @@
                         "product": {
                           "name": "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
                           "product_id": "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
                         }
                       }
                     ]
@@ -508,6 +1005,7 @@
       "product_status": {
         "fixed": [
           "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
           "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -526,6 +1024,65 @@
           "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
           "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.35.src",
           "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.35.x86_64",
           "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.35.x86_64",
@@ -564,6 +1121,7 @@
           "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
           "product_ids": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -582,6 +1140,65 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.35.src",
             "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.35.x86_64",
             "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.35.x86_64",
@@ -633,6 +1250,7 @@
           },
           "products": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -651,6 +1269,65 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.35.src",
             "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.35.x86_64",
             "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.35.x86_64",
@@ -690,6 +1367,7 @@
           "details": "Important",
           "product_ids": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -708,6 +1386,65 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.35.src",
             "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.35.x86_64",
             "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.35.x86_64",

--- a/csaf/vex/cve/2023/cve-2023-3390.json
+++ b/csaf/vex/cve/2023/cve-2023-3390.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-3390",
       "initial_release_date": "2024-08-14T19:41:55Z",
-      "current_release_date": "2025-06-04T20:19:16Z",
+      "current_release_date": "2025-09-05T21:45:35Z",
       "status": "final",
-      "version": "4",
+      "version": "5",
       "revision_history": [
         {
           "date": "2024-08-14T19:41:55Z",
@@ -47,6 +47,11 @@
         {
           "date": "2025-06-04T20:19:16Z",
           "number": "4",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-05T21:45:35Z",
+          "number": "5",
           "summary": "Updated version"
         }
       ]
@@ -76,6 +81,14 @@
                         "product": {
                           "name": "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
                           "product_id": "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src"
                         }
                       }
                     ]
@@ -226,6 +239,490 @@
                         "product": {
                           "name": "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
                           "product_id": "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
                         }
                       }
                     ]
@@ -508,6 +1005,7 @@
       "product_status": {
         "fixed": [
           "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
           "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -526,6 +1024,65 @@
           "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
           "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.35.src",
           "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.35.x86_64",
           "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.35.x86_64",
@@ -564,6 +1121,7 @@
           "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
           "product_ids": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -582,6 +1140,65 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.35.src",
             "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.35.x86_64",
             "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.35.x86_64",
@@ -633,6 +1250,7 @@
           },
           "products": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -651,6 +1269,65 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.35.src",
             "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.35.x86_64",
             "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.35.x86_64",
@@ -690,6 +1367,7 @@
           "details": "Important",
           "product_ids": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -708,6 +1386,65 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.35.src",
             "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.35.x86_64",
             "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.35.x86_64",

--- a/csaf/vex/cve/2023/cve-2023-35001.json
+++ b/csaf/vex/cve/2023/cve-2023-35001.json
@@ -1,0 +1,857 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2023-35001",
+    "tracking": {
+      "id": "CVE-2023-35001",
+      "initial_release_date": "2025-09-05T21:45:36Z",
+      "current_release_date": "2025-09-05T21:45:36Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2025-09-05T21:45:36Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2023-35001",
+      "notes": [
+        {
+          "category": "description",
+          "text": "An out-of-bounds (OOB) memory access flaw was found in the Netfilter module in the Linux kernel's nft_byteorder_eval in net/netfilter/nft_byteorder.c. A bound check failure allows a local attacker with CAP_NET_ADMIN access to cause a local privilege escalation issue due to incorrect data alignment."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
+          "product_ids": [
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 7.8,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Important",
+          "product_ids": [
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2023/cve-2023-35788.json
+++ b/csaf/vex/cve/2023/cve-2023-35788.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-35788",
       "initial_release_date": "2024-08-14T19:41:55Z",
-      "current_release_date": "2025-06-04T20:19:16Z",
+      "current_release_date": "2025-09-05T21:45:35Z",
       "status": "final",
-      "version": "3",
+      "version": "4",
       "revision_history": [
         {
           "date": "2024-08-14T19:41:55Z",
@@ -42,6 +42,11 @@
         {
           "date": "2025-06-04T20:19:16Z",
           "number": "3",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-05T21:45:35Z",
+          "number": "4",
           "summary": "Updated version"
         }
       ]
@@ -71,6 +76,14 @@
                         "product": {
                           "name": "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
                           "product_id": "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src"
                         }
                       }
                     ]
@@ -222,6 +235,490 @@
                           "name": "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
                           "product_id": "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64"
                         }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
                       }
                     ]
                   }
@@ -245,6 +742,7 @@
       "product_status": {
         "fixed": [
           "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
           "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -262,7 +760,66 @@
           "lts-8.6:kernel-rt-modules-extra-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
-          "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64"
+          "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
         ]
       },
       "remediations": [
@@ -271,6 +828,7 @@
           "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
           "product_ids": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -288,7 +846,66 @@
             "lts-8.6:kernel-rt-modules-extra-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
-            "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64"
+            "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
           ]
         }
       ],
@@ -310,6 +927,7 @@
           },
           "products": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -327,7 +945,66 @@
             "lts-8.6:kernel-rt-modules-extra-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
-            "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64"
+            "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
           ]
         }
       ],
@@ -337,6 +1014,7 @@
           "details": "Important",
           "product_ids": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -354,7 +1032,66 @@
             "lts-8.6:kernel-rt-modules-extra-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
-            "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64"
+            "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
           ]
         }
       ]

--- a/csaf/vex/cve/2023/cve-2023-3609.json
+++ b/csaf/vex/cve/2023/cve-2023-3609.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-3609",
       "initial_release_date": "2024-08-14T19:41:55Z",
-      "current_release_date": "2025-07-14T22:17:03Z",
+      "current_release_date": "2025-09-05T21:45:35Z",
       "status": "final",
-      "version": "6",
+      "version": "7",
       "revision_history": [
         {
           "date": "2024-08-14T19:41:55Z",
@@ -58,6 +58,11 @@
           "date": "2025-07-14T22:17:03Z",
           "number": "6",
           "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-05T21:45:35Z",
+          "number": "7",
+          "summary": "Updated version"
         }
       ]
     }
@@ -86,6 +91,14 @@
                         "product": {
                           "name": "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
                           "product_id": "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src"
                         }
                       }
                     ]
@@ -236,6 +249,490 @@
                         "product": {
                           "name": "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
                           "product_id": "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
                         }
                       }
                     ]
@@ -608,28 +1105,6 @@
                         "product": {
                           "name": "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.src",
                           "product_id": "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.src"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "category": "architecture",
-                    "name": "i686",
-                    "branches": [
-                      {
-                        "category": "product_version",
-                        "name": "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.i686",
-                        "product": {
-                          "name": "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.i686",
-                          "product_id": "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.i686"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.i686",
-                        "product": {
-                          "name": "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.i686",
-                          "product_id": "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.i686"
                         }
                       }
                     ]
@@ -1434,28 +1909,6 @@
                   },
                   {
                     "category": "architecture",
-                    "name": "i686",
-                    "branches": [
-                      {
-                        "category": "product_version",
-                        "name": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-                        "product": {
-                          "name": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-                          "product_id": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-                        "product": {
-                          "name": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-                          "product_id": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "category": "architecture",
                     "name": "noarch",
                     "branches": [
                       {
@@ -1964,6 +2417,7 @@
       "product_status": {
         "fixed": [
           "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
           "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -1982,6 +2436,65 @@
           "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
           "fips-9.2-compliant:kernel-5.14.0-284.30.1.el9_2.ciqfips.0.13.1.src",
           "fips-9.2-compliant:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.ciqfips.0.13.1.noarch",
           "fips-9.2-compliant:kernel-doc-5.14.0-284.30.1.el9_2.ciqfips.0.13.1.noarch",
@@ -2024,8 +2537,6 @@
           "fips-9.2-compliant:kernel-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.13.1.x86_64",
           "fips-9.2-compliant:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.13.1.x86_64",
           "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.src",
-          "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.i686",
-          "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.i686",
           "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.noarch",
           "lts-9.2:kernel-doc-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.noarch",
           "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.x86_64",
@@ -2122,8 +2633,6 @@
           "lts-9.2:kernel-64k-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.aarch64",
           "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.aarch64",
           "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.src",
-          "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-          "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
           "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
           "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
           "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.aarch64",
@@ -2191,6 +2700,7 @@
           "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
           "product_ids": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -2209,6 +2719,65 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "fips-9.2-compliant:kernel-5.14.0-284.30.1.el9_2.ciqfips.0.13.1.src",
             "fips-9.2-compliant:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.ciqfips.0.13.1.noarch",
             "fips-9.2-compliant:kernel-doc-5.14.0-284.30.1.el9_2.ciqfips.0.13.1.noarch",
@@ -2251,8 +2820,6 @@
             "fips-9.2-compliant:kernel-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.13.1.x86_64",
             "fips-9.2-compliant:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.13.1.x86_64",
             "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.src",
-            "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.i686",
-            "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.i686",
             "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.noarch",
             "lts-9.2:kernel-doc-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.noarch",
             "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.x86_64",
@@ -2349,8 +2916,6 @@
             "lts-9.2:kernel-64k-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.aarch64",
             "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.aarch64",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.src",
-            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.aarch64",
@@ -2431,6 +2996,7 @@
           },
           "products": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -2449,6 +3015,65 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "fips-9.2-compliant:kernel-5.14.0-284.30.1.el9_2.ciqfips.0.13.1.src",
             "fips-9.2-compliant:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.ciqfips.0.13.1.noarch",
             "fips-9.2-compliant:kernel-doc-5.14.0-284.30.1.el9_2.ciqfips.0.13.1.noarch",
@@ -2491,8 +3116,6 @@
             "fips-9.2-compliant:kernel-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.13.1.x86_64",
             "fips-9.2-compliant:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.13.1.x86_64",
             "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.src",
-            "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.i686",
-            "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.i686",
             "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.noarch",
             "lts-9.2:kernel-doc-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.noarch",
             "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.x86_64",
@@ -2589,8 +3212,6 @@
             "lts-9.2:kernel-64k-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.aarch64",
             "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.aarch64",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.src",
-            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.aarch64",
@@ -2659,6 +3280,7 @@
           "details": "Important",
           "product_ids": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -2677,6 +3299,65 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
             "fips-9.2-compliant:kernel-5.14.0-284.30.1.el9_2.ciqfips.0.13.1.src",
             "fips-9.2-compliant:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.ciqfips.0.13.1.noarch",
             "fips-9.2-compliant:kernel-doc-5.14.0-284.30.1.el9_2.ciqfips.0.13.1.noarch",
@@ -2719,8 +3400,6 @@
             "fips-9.2-compliant:kernel-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.13.1.x86_64",
             "fips-9.2-compliant:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.13.1.x86_64",
             "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.src",
-            "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.i686",
-            "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.i686",
             "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.noarch",
             "lts-9.2:kernel-doc-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.noarch",
             "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.x86_64",
@@ -2817,8 +3496,6 @@
             "lts-9.2:kernel-64k-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.aarch64",
             "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.aarch64",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.src",
-            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.aarch64",

--- a/csaf/vex/cve/2023/cve-2023-3611.json
+++ b/csaf/vex/cve/2023/cve-2023-3611.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-3611",
       "initial_release_date": "2025-07-07T12:05:55Z",
-      "current_release_date": "2025-07-14T22:17:03Z",
+      "current_release_date": "2025-09-05T22:05:42Z",
       "status": "final",
-      "version": "2",
+      "version": "3",
       "revision_history": [
         {
           "date": "2025-07-07T12:05:55Z",
@@ -37,6 +37,11 @@
         {
           "date": "2025-07-14T22:17:03Z",
           "number": "2",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-05T22:05:42Z",
+          "number": "3",
           "summary": "Updated version"
         }
       ]
@@ -346,28 +351,6 @@
                         "product": {
                           "name": "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.src",
                           "product_id": "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.src"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "category": "architecture",
-                    "name": "i686",
-                    "branches": [
-                      {
-                        "category": "product_version",
-                        "name": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-                        "product": {
-                          "name": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-                          "product_id": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-                        "product": {
-                          "name": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-                          "product_id": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686"
                         }
                       }
                     ]
@@ -863,6 +846,516 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -914,8 +1407,6 @@
           "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
           "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
           "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.src",
-          "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-          "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
           "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
           "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
           "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.aarch64",
@@ -974,7 +1465,67 @@
           "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
           "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
           "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-          "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64"
+          "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
         ]
       },
       "remediations": [
@@ -1015,8 +1566,6 @@
             "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
             "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.src",
-            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.aarch64",
@@ -1075,7 +1624,67 @@
             "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
             "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
             "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64"
+            "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
           ]
         }
       ],
@@ -1129,8 +1738,6 @@
             "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
             "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.src",
-            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.aarch64",
@@ -1189,7 +1796,67 @@
             "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
             "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
             "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64"
+            "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
           ]
         }
       ],
@@ -1231,8 +1898,6 @@
             "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
             "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.src",
-            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.aarch64",
@@ -1291,7 +1956,67 @@
             "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
             "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
             "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64"
+            "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
           ]
         }
       ]

--- a/csaf/vex/cve/2023/cve-2023-3776.json
+++ b/csaf/vex/cve/2023/cve-2023-3776.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-3776",
       "initial_release_date": "2024-08-14T19:41:55Z",
-      "current_release_date": "2025-06-04T20:19:16Z",
+      "current_release_date": "2025-09-05T21:45:36Z",
       "status": "final",
-      "version": "3",
+      "version": "4",
       "revision_history": [
         {
           "date": "2024-08-14T19:41:55Z",
@@ -42,6 +42,11 @@
         {
           "date": "2025-06-04T20:19:16Z",
           "number": "3",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-05T21:45:36Z",
+          "number": "4",
           "summary": "Updated version"
         }
       ]
@@ -71,6 +76,14 @@
                         "product": {
                           "name": "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
                           "product_id": "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src"
                         }
                       }
                     ]
@@ -222,6 +235,490 @@
                           "name": "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
                           "product_id": "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64"
                         }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
                       }
                     ]
                   }
@@ -245,6 +742,7 @@
       "product_status": {
         "fixed": [
           "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
           "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -262,7 +760,66 @@
           "lts-8.6:kernel-rt-modules-extra-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
-          "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64"
+          "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
         ]
       },
       "remediations": [
@@ -271,6 +828,7 @@
           "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
           "product_ids": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -288,7 +846,66 @@
             "lts-8.6:kernel-rt-modules-extra-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
-            "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64"
+            "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
           ]
         }
       ],
@@ -310,6 +927,7 @@
           },
           "products": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -327,7 +945,66 @@
             "lts-8.6:kernel-rt-modules-extra-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
-            "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64"
+            "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
           ]
         }
       ],
@@ -337,6 +1014,7 @@
           "details": "Important",
           "product_ids": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -354,7 +1032,66 @@
             "lts-8.6:kernel-rt-modules-extra-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
-            "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64"
+            "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
           ]
         }
       ]

--- a/csaf/vex/cve/2023/cve-2023-3812.json
+++ b/csaf/vex/cve/2023/cve-2023-3812.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-3812",
       "initial_release_date": "2025-05-19T12:13:39Z",
-      "current_release_date": "2025-06-18T16:12:19Z",
+      "current_release_date": "2025-09-05T22:05:42Z",
       "status": "final",
-      "version": "4",
+      "version": "5",
       "revision_history": [
         {
           "date": "2025-05-19T12:13:39Z",
@@ -47,6 +47,11 @@
         {
           "date": "2025-06-18T16:12:19Z",
           "number": "4",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-05T22:05:42Z",
+          "number": "5",
           "summary": "Updated version"
         }
       ]
@@ -76,28 +81,6 @@
                         "product": {
                           "name": "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.5.2.src",
                           "product_id": "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.5.2.src"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "category": "architecture",
-                    "name": "i686",
-                    "branches": [
-                      {
-                        "category": "product_version",
-                        "name": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.5.2.i686",
-                        "product": {
-                          "name": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.5.2.i686",
-                          "product_id": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.5.2.i686"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.5.2.i686",
-                        "product": {
-                          "name": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.5.2.i686",
-                          "product_id": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.5.2.i686"
                         }
                       }
                     ]
@@ -1531,6 +1514,516 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -1550,8 +2043,6 @@
       "product_status": {
         "fixed": [
           "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.5.2.src",
-          "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.5.2.i686",
-          "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.5.2.i686",
           "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.5.2.noarch",
           "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.5.2.noarch",
           "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.5.2.aarch64",
@@ -1722,7 +2213,67 @@
           "fips-9.2-compliant:kernel-debug-uki-virt-5.14.0-284.30.1.el9_2.ciqfips.0.13.1.x86_64",
           "fips-9.2-compliant:kernel-uki-virt-5.14.0-284.30.1.el9_2.ciqfips.0.13.1.x86_64",
           "fips-9.2-compliant:kernel-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.13.1.x86_64",
-          "fips-9.2-compliant:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.13.1.x86_64"
+          "fips-9.2-compliant:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.13.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
         ]
       },
       "remediations": [
@@ -1731,8 +2282,6 @@
           "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
           "product_ids": [
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.5.2.src",
-            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.5.2.i686",
-            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.5.2.i686",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.5.2.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.5.2.noarch",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.5.2.aarch64",
@@ -1903,7 +2452,67 @@
             "fips-9.2-compliant:kernel-debug-uki-virt-5.14.0-284.30.1.el9_2.ciqfips.0.13.1.x86_64",
             "fips-9.2-compliant:kernel-uki-virt-5.14.0-284.30.1.el9_2.ciqfips.0.13.1.x86_64",
             "fips-9.2-compliant:kernel-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.13.1.x86_64",
-            "fips-9.2-compliant:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.13.1.x86_64"
+            "fips-9.2-compliant:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.13.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
           ]
         }
       ],
@@ -1925,8 +2534,6 @@
           },
           "products": [
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.5.2.src",
-            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.5.2.i686",
-            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.5.2.i686",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.5.2.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.5.2.noarch",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.5.2.aarch64",
@@ -2097,7 +2704,67 @@
             "fips-9.2-compliant:kernel-debug-uki-virt-5.14.0-284.30.1.el9_2.ciqfips.0.13.1.x86_64",
             "fips-9.2-compliant:kernel-uki-virt-5.14.0-284.30.1.el9_2.ciqfips.0.13.1.x86_64",
             "fips-9.2-compliant:kernel-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.13.1.x86_64",
-            "fips-9.2-compliant:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.13.1.x86_64"
+            "fips-9.2-compliant:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.13.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
           ]
         }
       ],
@@ -2107,8 +2774,6 @@
           "details": "Important",
           "product_ids": [
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.5.2.src",
-            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.5.2.i686",
-            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.5.2.i686",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.5.2.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.5.2.noarch",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.5.2.aarch64",
@@ -2279,7 +2944,67 @@
             "fips-9.2-compliant:kernel-debug-uki-virt-5.14.0-284.30.1.el9_2.ciqfips.0.13.1.x86_64",
             "fips-9.2-compliant:kernel-uki-virt-5.14.0-284.30.1.el9_2.ciqfips.0.13.1.x86_64",
             "fips-9.2-compliant:kernel-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.13.1.x86_64",
-            "fips-9.2-compliant:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.13.1.x86_64"
+            "fips-9.2-compliant:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.13.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
           ]
         }
       ]

--- a/csaf/vex/cve/2023/cve-2023-4004.json
+++ b/csaf/vex/cve/2023/cve-2023-4004.json
@@ -1,0 +1,857 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2023-4004",
+    "tracking": {
+      "id": "CVE-2023-4004",
+      "initial_release_date": "2025-09-05T21:45:36Z",
+      "current_release_date": "2025-09-05T21:45:36Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2025-09-05T21:45:36Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2023-4004",
+      "notes": [
+        {
+          "category": "description",
+          "text": "A use-after-free flaw was found in the Linux kernel's netfilter in the way a user triggers the nft_pipapo_remove function with the element, without a NFT_SET_EXT_KEY_END. This issue could allow a local user to crash the system or potentially escalate their privileges on the system."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
+          "product_ids": [
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 7.8,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Important",
+          "product_ids": [
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2023/cve-2023-4128.json
+++ b/csaf/vex/cve/2023/cve-2023-4128.json
@@ -1,0 +1,857 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "text": "Copyright (c) CIQ, Inc. All rights reserved. Some vulnerability data may have been imported from https://access.redhat.com/security/data/csaf/v2/vex/ licensed under the same terms and copyright (c) Red Hat, Inc. All rights reserved.",
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/"
+      }
+    },
+    "notes": [
+      {
+        "category": "legal_disclaimer",
+        "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to the original copyright holder(s) and provide a link to the original.",
+        "title": "Terms of Use"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "CIQ",
+      "namespace": "https://www.ciq.com"
+    },
+    "title": "CIQ Security Advisory: Remediation of CVE-2023-4128",
+    "tracking": {
+      "id": "CVE-2023-4128",
+      "initial_release_date": "2025-09-05T21:45:36Z",
+      "current_release_date": "2025-09-05T21:45:36Z",
+      "status": "final",
+      "version": "1",
+      "revision_history": [
+        {
+          "date": "2025-09-05T21:45:36Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ]
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "CIQ",
+        "branches": [
+          {
+            "category": "product_family",
+            "name": "CIQ LTS for Rocky Linux and CentOS",
+            "branches": [
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2023-4128",
+      "notes": [
+        {
+          "category": "description",
+          "text": "This record is a duplicate of CVE-2023-4206, CVE-2023-4207, and CVE-2023-4208. Do not use this CVE record: CVE-2023-4128."
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+        ]
+      },
+      "remediations": [
+        {
+          "category": "vendor_fix",
+          "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
+          "product_ids": [
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+          ]
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "attackComplexity": "LOW",
+            "attackVector": "LOCAL",
+            "availabilityImpact": "HIGH",
+            "baseScore": 7.8,
+            "baseSeverity": "HIGH",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "LOW",
+            "scope": "UNCHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+            "version": "3.1"
+          },
+          "products": [
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Important",
+          "product_ids": [
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/csaf/vex/cve/2023/cve-2023-4206.json
+++ b/csaf/vex/cve/2023/cve-2023-4206.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-4206",
       "initial_release_date": "2025-04-24T03:04:31Z",
-      "current_release_date": "2025-06-04T20:19:16Z",
+      "current_release_date": "2025-09-05T21:45:36Z",
       "status": "final",
-      "version": "5",
+      "version": "6",
       "revision_history": [
         {
           "date": "2025-04-24T03:04:31Z",
@@ -52,6 +52,11 @@
         {
           "date": "2025-06-04T20:19:16Z",
           "number": "5",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-05T21:45:36Z",
+          "number": "6",
           "summary": "Updated version"
         }
       ]
@@ -89,28 +94,6 @@
                         "product": {
                           "name": "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.src",
                           "product_id": "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.src"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "category": "architecture",
-                    "name": "i686",
-                    "branches": [
-                      {
-                        "category": "product_version",
-                        "name": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.i686",
-                        "product": {
-                          "name": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.i686",
-                          "product_id": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.i686"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.i686",
-                        "product": {
-                          "name": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.i686",
-                          "product_id": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.i686"
                         }
                       }
                     ]
@@ -1118,6 +1101,14 @@
                           "name": "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.src",
                           "product_id": "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.src"
                         }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src"
+                        }
                       }
                     ]
                   },
@@ -1268,6 +1259,490 @@
                           "name": "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
                           "product_id": "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64"
                         }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
                       }
                     ]
                   }
@@ -1291,8 +1766,7 @@
       "product_status": {
         "fixed": [
           "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.src",
-          "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.i686",
-          "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.i686",
+          "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.src",
           "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.noarch",
           "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.noarch",
           "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.aarch64",
@@ -1352,6 +1826,24 @@
           "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.x86_64",
           "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.x86_64",
           "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.x86_64",
+          "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-debuginfo-common-x86_64-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-selftests-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-debug-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-debug-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-debug-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-debug-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-debug-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-debug-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-debug-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-debug-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
           "fips-9.2-compliant:kernel-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.src",
           "fips-9.2-compliant:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.noarch",
           "fips-9.2-compliant:kernel-doc-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.noarch",
@@ -1394,6 +1886,7 @@
           "fips-9.2-compliant:kernel-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.x86_64",
           "fips-9.2-compliant:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.x86_64",
           "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.src",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
           "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
           "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
           "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
@@ -1412,25 +1905,65 @@
           "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
           "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
           "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
-          "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.src",
-          "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-debuginfo-common-x86_64-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-selftests-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-debug-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-debug-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-debug-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-debug-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-debug-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-debug-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-debug-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-debug-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64"
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
         ]
       },
       "remediations": [
@@ -1439,8 +1972,7 @@
           "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
           "product_ids": [
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.src",
-            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.i686",
-            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.i686",
+            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.src",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.noarch",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.aarch64",
@@ -1500,6 +2032,24 @@
             "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.x86_64",
             "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.x86_64",
             "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.x86_64",
+            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debuginfo-common-x86_64-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-selftests-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
             "fips-9.2-compliant:kernel-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.src",
             "fips-9.2-compliant:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.noarch",
             "fips-9.2-compliant:kernel-doc-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.noarch",
@@ -1542,6 +2092,7 @@
             "fips-9.2-compliant:kernel-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.x86_64",
             "fips-9.2-compliant:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.x86_64",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
@@ -1560,25 +2111,65 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
-            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.src",
-            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debuginfo-common-x86_64-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-selftests-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64"
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
           ]
         }
       ],
@@ -1600,8 +2191,7 @@
           },
           "products": [
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.src",
-            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.i686",
-            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.i686",
+            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.src",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.noarch",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.aarch64",
@@ -1661,6 +2251,24 @@
             "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.x86_64",
             "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.x86_64",
             "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.x86_64",
+            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debuginfo-common-x86_64-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-selftests-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
             "fips-9.2-compliant:kernel-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.src",
             "fips-9.2-compliant:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.noarch",
             "fips-9.2-compliant:kernel-doc-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.noarch",
@@ -1703,6 +2311,7 @@
             "fips-9.2-compliant:kernel-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.x86_64",
             "fips-9.2-compliant:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.x86_64",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
@@ -1721,25 +2330,65 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
-            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.src",
-            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debuginfo-common-x86_64-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-selftests-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64"
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
           ]
         }
       ],
@@ -1749,8 +2398,7 @@
           "details": "Important",
           "product_ids": [
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.src",
-            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.i686",
-            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.i686",
+            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.src",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.noarch",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.aarch64",
@@ -1810,6 +2458,24 @@
             "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.x86_64",
             "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.x86_64",
             "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.x86_64",
+            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debuginfo-common-x86_64-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-selftests-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
             "fips-9.2-compliant:kernel-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.src",
             "fips-9.2-compliant:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.noarch",
             "fips-9.2-compliant:kernel-doc-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.noarch",
@@ -1852,6 +2518,7 @@
             "fips-9.2-compliant:kernel-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.x86_64",
             "fips-9.2-compliant:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.x86_64",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
@@ -1870,25 +2537,65 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
-            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.src",
-            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debuginfo-common-x86_64-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-selftests-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64"
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
           ]
         }
       ]

--- a/csaf/vex/cve/2023/cve-2023-4207.json
+++ b/csaf/vex/cve/2023/cve-2023-4207.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-4207",
       "initial_release_date": "2025-04-24T03:04:31Z",
-      "current_release_date": "2025-06-04T20:19:16Z",
+      "current_release_date": "2025-09-05T21:45:36Z",
       "status": "final",
-      "version": "7",
+      "version": "8",
       "revision_history": [
         {
           "date": "2025-04-24T03:04:31Z",
@@ -62,6 +62,11 @@
         {
           "date": "2025-06-04T20:19:16Z",
           "number": "7",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-05T21:45:36Z",
+          "number": "8",
           "summary": "Updated version"
         }
       ]
@@ -99,28 +104,6 @@
                         "product": {
                           "name": "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.src",
                           "product_id": "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.src"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "category": "architecture",
-                    "name": "i686",
-                    "branches": [
-                      {
-                        "category": "product_version",
-                        "name": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.i686",
-                        "product": {
-                          "name": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.i686",
-                          "product_id": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.i686"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.i686",
-                        "product": {
-                          "name": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.i686",
-                          "product_id": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.i686"
                         }
                       }
                     ]
@@ -1141,28 +1124,6 @@
                   },
                   {
                     "category": "architecture",
-                    "name": "i686",
-                    "branches": [
-                      {
-                        "category": "product_version",
-                        "name": "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.i686",
-                        "product": {
-                          "name": "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.i686",
-                          "product_id": "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.i686"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.i686",
-                        "product": {
-                          "name": "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.i686",
-                          "product_id": "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.i686"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "category": "architecture",
                     "name": "noarch",
                     "branches": [
                       {
@@ -2148,6 +2109,14 @@
                           "name": "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.src",
                           "product_id": "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.src"
                         }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src"
+                        }
                       }
                     ]
                   },
@@ -2298,6 +2267,490 @@
                           "name": "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
                           "product_id": "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64"
                         }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
                       }
                     ]
                   }
@@ -2321,8 +2774,7 @@
       "product_status": {
         "fixed": [
           "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.src",
-          "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.i686",
-          "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.i686",
+          "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.src",
           "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.noarch",
           "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.noarch",
           "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.aarch64",
@@ -2382,6 +2834,24 @@
           "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.x86_64",
           "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.x86_64",
           "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.x86_64",
+          "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-debuginfo-common-x86_64-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-selftests-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-debug-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-debug-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-debug-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-debug-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-debug-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-debug-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-debug-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-debug-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
           "fips-9.2-compliant:kernel-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.src",
           "fips-9.2-compliant:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.noarch",
           "fips-9.2-compliant:kernel-doc-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.noarch",
@@ -2424,8 +2894,7 @@
           "fips-9.2-compliant:kernel-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.x86_64",
           "fips-9.2-compliant:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.x86_64",
           "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.src",
-          "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.i686",
-          "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.i686",
+          "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.src",
           "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.noarch",
           "lts-9.2:kernel-doc-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.noarch",
           "lts-9.2:kernel-debug-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.x86_64",
@@ -2466,6 +2935,30 @@
           "lts-9.2:kernel-debug-uki-virt-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.x86_64",
           "lts-9.2:kernel-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.x86_64",
           "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.x86_64",
+          "lts-9.2:kernel-rt-debug-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debug-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debug-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debug-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debug-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debug-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-selftests-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debug-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debug-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debuginfo-common-x86_64-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debug-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debug-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debug-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
           "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
           "lts-9.2:kernel-64k-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
           "lts-9.2:kernel-64k-devel-matched-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
@@ -2521,32 +3014,8 @@
           "lts-9.2:kernel-64k-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
           "lts-9.2:kernel-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
           "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
-          "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.src",
-          "lts-9.2:kernel-rt-debug-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debug-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debug-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debug-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debug-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debug-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-selftests-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debug-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debug-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debuginfo-common-x86_64-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debug-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debug-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debug-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
           "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.src",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
           "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
           "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
           "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
@@ -2565,25 +3034,65 @@
           "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
           "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
           "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
-          "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.src",
-          "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-debuginfo-common-x86_64-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-selftests-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-debug-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-debug-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-debug-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-debug-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-debug-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-debug-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-debug-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-debug-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64"
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
         ]
       },
       "remediations": [
@@ -2592,8 +3101,7 @@
           "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
           "product_ids": [
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.src",
-            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.i686",
-            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.i686",
+            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.src",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.noarch",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.aarch64",
@@ -2653,6 +3161,24 @@
             "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.x86_64",
             "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.x86_64",
             "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.x86_64",
+            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debuginfo-common-x86_64-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-selftests-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
             "fips-9.2-compliant:kernel-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.src",
             "fips-9.2-compliant:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.noarch",
             "fips-9.2-compliant:kernel-doc-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.noarch",
@@ -2695,8 +3221,7 @@
             "fips-9.2-compliant:kernel-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.x86_64",
             "fips-9.2-compliant:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.x86_64",
             "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.src",
-            "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.i686",
-            "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.i686",
+            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.src",
             "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.noarch",
             "lts-9.2:kernel-doc-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.noarch",
             "lts-9.2:kernel-debug-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.x86_64",
@@ -2737,6 +3262,30 @@
             "lts-9.2:kernel-debug-uki-virt-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.x86_64",
             "lts-9.2:kernel-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.x86_64",
             "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.x86_64",
+            "lts-9.2:kernel-rt-debug-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-selftests-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debuginfo-common-x86_64-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
             "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
             "lts-9.2:kernel-64k-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
             "lts-9.2:kernel-64k-devel-matched-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
@@ -2792,32 +3341,8 @@
             "lts-9.2:kernel-64k-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
             "lts-9.2:kernel-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
             "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
-            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.src",
-            "lts-9.2:kernel-rt-debug-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-selftests-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debuginfo-common-x86_64-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
@@ -2836,25 +3361,65 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
-            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.src",
-            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debuginfo-common-x86_64-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-selftests-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64"
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
           ]
         }
       ],
@@ -2876,8 +3441,7 @@
           },
           "products": [
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.src",
-            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.i686",
-            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.i686",
+            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.src",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.noarch",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.aarch64",
@@ -2937,6 +3501,24 @@
             "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.x86_64",
             "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.x86_64",
             "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.x86_64",
+            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debuginfo-common-x86_64-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-selftests-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
             "fips-9.2-compliant:kernel-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.src",
             "fips-9.2-compliant:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.noarch",
             "fips-9.2-compliant:kernel-doc-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.noarch",
@@ -2979,8 +3561,7 @@
             "fips-9.2-compliant:kernel-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.x86_64",
             "fips-9.2-compliant:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.x86_64",
             "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.src",
-            "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.i686",
-            "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.i686",
+            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.src",
             "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.noarch",
             "lts-9.2:kernel-doc-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.noarch",
             "lts-9.2:kernel-debug-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.x86_64",
@@ -3021,6 +3602,30 @@
             "lts-9.2:kernel-debug-uki-virt-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.x86_64",
             "lts-9.2:kernel-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.x86_64",
             "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.x86_64",
+            "lts-9.2:kernel-rt-debug-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-selftests-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debuginfo-common-x86_64-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
             "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
             "lts-9.2:kernel-64k-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
             "lts-9.2:kernel-64k-devel-matched-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
@@ -3076,32 +3681,8 @@
             "lts-9.2:kernel-64k-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
             "lts-9.2:kernel-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
             "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
-            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.src",
-            "lts-9.2:kernel-rt-debug-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-selftests-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debuginfo-common-x86_64-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
@@ -3120,25 +3701,65 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
-            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.src",
-            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debuginfo-common-x86_64-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-selftests-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64"
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
           ]
         }
       ],
@@ -3148,8 +3769,7 @@
           "details": "Important",
           "product_ids": [
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.src",
-            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.i686",
-            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.i686",
+            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.src",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.noarch",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.aarch64",
@@ -3209,6 +3829,24 @@
             "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.x86_64",
             "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.x86_64",
             "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.x86_64",
+            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debuginfo-common-x86_64-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-selftests-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
             "fips-9.2-compliant:kernel-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.src",
             "fips-9.2-compliant:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.noarch",
             "fips-9.2-compliant:kernel-doc-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.noarch",
@@ -3251,8 +3889,7 @@
             "fips-9.2-compliant:kernel-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.x86_64",
             "fips-9.2-compliant:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.x86_64",
             "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.src",
-            "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.i686",
-            "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.i686",
+            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.src",
             "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.noarch",
             "lts-9.2:kernel-doc-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.noarch",
             "lts-9.2:kernel-debug-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.x86_64",
@@ -3293,6 +3930,30 @@
             "lts-9.2:kernel-debug-uki-virt-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.x86_64",
             "lts-9.2:kernel-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.x86_64",
             "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.x86_64",
+            "lts-9.2:kernel-rt-debug-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-selftests-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debuginfo-common-x86_64-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
             "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
             "lts-9.2:kernel-64k-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
             "lts-9.2:kernel-64k-devel-matched-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
@@ -3348,32 +4009,8 @@
             "lts-9.2:kernel-64k-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
             "lts-9.2:kernel-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
             "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
-            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.src",
-            "lts-9.2:kernel-rt-debug-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-selftests-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debuginfo-common-x86_64-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
@@ -3392,25 +4029,65 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
-            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.src",
-            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debuginfo-common-x86_64-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-selftests-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64"
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
           ]
         }
       ]

--- a/csaf/vex/cve/2023/cve-2023-4208.json
+++ b/csaf/vex/cve/2023/cve-2023-4208.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-4208",
       "initial_release_date": "2025-04-24T03:04:31Z",
-      "current_release_date": "2025-06-04T20:19:16Z",
+      "current_release_date": "2025-09-05T21:45:36Z",
       "status": "final",
-      "version": "7",
+      "version": "8",
       "revision_history": [
         {
           "date": "2025-04-24T03:04:31Z",
@@ -62,6 +62,11 @@
         {
           "date": "2025-06-04T20:19:16Z",
           "number": "7",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-05T21:45:36Z",
+          "number": "8",
           "summary": "Updated version"
         }
       ]
@@ -99,28 +104,6 @@
                         "product": {
                           "name": "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.src",
                           "product_id": "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.src"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "category": "architecture",
-                    "name": "i686",
-                    "branches": [
-                      {
-                        "category": "product_version",
-                        "name": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.i686",
-                        "product": {
-                          "name": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.i686",
-                          "product_id": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.i686"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.i686",
-                        "product": {
-                          "name": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.i686",
-                          "product_id": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.i686"
                         }
                       }
                     ]
@@ -1141,28 +1124,6 @@
                   },
                   {
                     "category": "architecture",
-                    "name": "i686",
-                    "branches": [
-                      {
-                        "category": "product_version",
-                        "name": "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.i686",
-                        "product": {
-                          "name": "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.i686",
-                          "product_id": "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.i686"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.i686",
-                        "product": {
-                          "name": "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.i686",
-                          "product_id": "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.i686"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "category": "architecture",
                     "name": "noarch",
                     "branches": [
                       {
@@ -2148,6 +2109,14 @@
                           "name": "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.src",
                           "product_id": "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.src"
                         }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src"
+                        }
                       }
                     ]
                   },
@@ -2298,6 +2267,490 @@
                           "name": "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
                           "product_id": "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64"
                         }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
+                        }
                       }
                     ]
                   }
@@ -2321,8 +2774,7 @@
       "product_status": {
         "fixed": [
           "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.src",
-          "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.i686",
-          "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.i686",
+          "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.src",
           "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.noarch",
           "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.noarch",
           "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.aarch64",
@@ -2382,6 +2834,24 @@
           "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.x86_64",
           "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.x86_64",
           "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.x86_64",
+          "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-debuginfo-common-x86_64-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-selftests-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-debug-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-debug-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-debug-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-debug-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-debug-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-debug-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-debug-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-debug-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+          "lts-8.8:kernel-rt-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
           "fips-9.2-compliant:kernel-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.src",
           "fips-9.2-compliant:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.noarch",
           "fips-9.2-compliant:kernel-doc-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.noarch",
@@ -2424,8 +2894,7 @@
           "fips-9.2-compliant:kernel-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.x86_64",
           "fips-9.2-compliant:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.x86_64",
           "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.src",
-          "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.i686",
-          "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.i686",
+          "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.src",
           "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.noarch",
           "lts-9.2:kernel-doc-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.noarch",
           "lts-9.2:kernel-debug-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.x86_64",
@@ -2466,6 +2935,30 @@
           "lts-9.2:kernel-debug-uki-virt-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.x86_64",
           "lts-9.2:kernel-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.x86_64",
           "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.x86_64",
+          "lts-9.2:kernel-rt-debug-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debug-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debug-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debug-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debug-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debug-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-selftests-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debug-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debug-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debuginfo-common-x86_64-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debug-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debug-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debug-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
           "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
           "lts-9.2:kernel-64k-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
           "lts-9.2:kernel-64k-devel-matched-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
@@ -2521,32 +3014,8 @@
           "lts-9.2:kernel-64k-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
           "lts-9.2:kernel-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
           "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
-          "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.src",
-          "lts-9.2:kernel-rt-debug-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debug-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debug-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debug-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debug-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debug-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-selftests-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debug-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debug-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debuginfo-common-x86_64-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debug-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debug-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debug-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
           "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.src",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
           "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
           "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
           "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
@@ -2565,25 +3034,65 @@
           "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
           "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
           "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
-          "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.src",
-          "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-debuginfo-common-x86_64-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-selftests-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-debug-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-debug-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-debug-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-debug-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-debug-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-debug-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-debug-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-debug-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-rt-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64"
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
         ]
       },
       "remediations": [
@@ -2592,8 +3101,7 @@
           "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
           "product_ids": [
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.src",
-            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.i686",
-            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.i686",
+            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.src",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.noarch",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.aarch64",
@@ -2653,6 +3161,24 @@
             "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.x86_64",
             "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.x86_64",
             "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.x86_64",
+            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debuginfo-common-x86_64-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-selftests-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
             "fips-9.2-compliant:kernel-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.src",
             "fips-9.2-compliant:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.noarch",
             "fips-9.2-compliant:kernel-doc-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.noarch",
@@ -2695,8 +3221,7 @@
             "fips-9.2-compliant:kernel-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.x86_64",
             "fips-9.2-compliant:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.x86_64",
             "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.src",
-            "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.i686",
-            "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.i686",
+            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.src",
             "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.noarch",
             "lts-9.2:kernel-doc-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.noarch",
             "lts-9.2:kernel-debug-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.x86_64",
@@ -2737,6 +3262,30 @@
             "lts-9.2:kernel-debug-uki-virt-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.x86_64",
             "lts-9.2:kernel-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.x86_64",
             "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.x86_64",
+            "lts-9.2:kernel-rt-debug-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-selftests-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debuginfo-common-x86_64-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
             "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
             "lts-9.2:kernel-64k-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
             "lts-9.2:kernel-64k-devel-matched-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
@@ -2792,32 +3341,8 @@
             "lts-9.2:kernel-64k-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
             "lts-9.2:kernel-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
             "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
-            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.src",
-            "lts-9.2:kernel-rt-debug-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-selftests-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debuginfo-common-x86_64-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
@@ -2836,25 +3361,65 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
-            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.src",
-            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debuginfo-common-x86_64-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-selftests-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64"
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
           ]
         }
       ],
@@ -2876,8 +3441,7 @@
           },
           "products": [
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.src",
-            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.i686",
-            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.i686",
+            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.src",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.noarch",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.aarch64",
@@ -2937,6 +3501,24 @@
             "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.x86_64",
             "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.x86_64",
             "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.x86_64",
+            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debuginfo-common-x86_64-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-selftests-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
             "fips-9.2-compliant:kernel-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.src",
             "fips-9.2-compliant:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.noarch",
             "fips-9.2-compliant:kernel-doc-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.noarch",
@@ -2979,8 +3561,7 @@
             "fips-9.2-compliant:kernel-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.x86_64",
             "fips-9.2-compliant:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.x86_64",
             "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.src",
-            "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.i686",
-            "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.i686",
+            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.src",
             "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.noarch",
             "lts-9.2:kernel-doc-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.noarch",
             "lts-9.2:kernel-debug-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.x86_64",
@@ -3021,6 +3602,30 @@
             "lts-9.2:kernel-debug-uki-virt-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.x86_64",
             "lts-9.2:kernel-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.x86_64",
             "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.x86_64",
+            "lts-9.2:kernel-rt-debug-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-selftests-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debuginfo-common-x86_64-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
             "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
             "lts-9.2:kernel-64k-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
             "lts-9.2:kernel-64k-devel-matched-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
@@ -3076,32 +3681,8 @@
             "lts-9.2:kernel-64k-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
             "lts-9.2:kernel-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
             "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
-            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.src",
-            "lts-9.2:kernel-rt-debug-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-selftests-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debuginfo-common-x86_64-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
@@ -3120,25 +3701,65 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
-            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.src",
-            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debuginfo-common-x86_64-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-selftests-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64"
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
           ]
         }
       ],
@@ -3148,8 +3769,7 @@
           "details": "Important",
           "product_ids": [
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.src",
-            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.i686",
-            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.i686",
+            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.src",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.noarch",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.aarch64",
@@ -3209,6 +3829,24 @@
             "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.x86_64",
             "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.x86_64",
             "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.4.1.x86_64",
+            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debuginfo-common-x86_64-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-selftests-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debug-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
+            "lts-8.8:kernel-rt-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
             "fips-9.2-compliant:kernel-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.src",
             "fips-9.2-compliant:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.noarch",
             "fips-9.2-compliant:kernel-doc-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.noarch",
@@ -3251,8 +3889,7 @@
             "fips-9.2-compliant:kernel-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.x86_64",
             "fips-9.2-compliant:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.11.1.x86_64",
             "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.src",
-            "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.i686",
-            "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.i686",
+            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.src",
             "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.noarch",
             "lts-9.2:kernel-doc-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.noarch",
             "lts-9.2:kernel-debug-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.x86_64",
@@ -3293,6 +3930,30 @@
             "lts-9.2:kernel-debug-uki-virt-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.x86_64",
             "lts-9.2:kernel-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.x86_64",
             "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.x86_64",
+            "lts-9.2:kernel-rt-debug-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-selftests-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debuginfo-common-x86_64-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
             "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
             "lts-9.2:kernel-64k-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
             "lts-9.2:kernel-64k-devel-matched-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
@@ -3348,32 +4009,8 @@
             "lts-9.2:kernel-64k-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
             "lts-9.2:kernel-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
             "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.5.2.aarch64",
-            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.src",
-            "lts-9.2:kernel-rt-debug-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-selftests-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debuginfo-common-x86_64-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
@@ -3392,25 +4029,65 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
-            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.src",
-            "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debuginfo-common-x86_64-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-selftests-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debug-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-core-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-devel-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-modules-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-modules-extra-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-rt-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64"
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.0.5.aarch64"
           ]
         }
       ]

--- a/csaf/vex/cve/2023/cve-2023-42753.json
+++ b/csaf/vex/cve/2023/cve-2023-42753.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-42753",
       "initial_release_date": "2025-07-07T12:05:55Z",
-      "current_release_date": "2025-07-17T17:38:40Z",
+      "current_release_date": "2025-09-05T22:05:42Z",
       "status": "final",
-      "version": "4",
+      "version": "5",
       "revision_history": [
         {
           "date": "2025-07-07T12:05:55Z",
@@ -47,6 +47,11 @@
         {
           "date": "2025-07-17T17:38:40Z",
           "number": "4",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-05T22:05:42Z",
+          "number": "5",
           "summary": "Updated version"
         }
       ]
@@ -356,28 +361,6 @@
                         "product": {
                           "name": "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.src",
                           "product_id": "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.src"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "category": "architecture",
-                    "name": "i686",
-                    "branches": [
-                      {
-                        "category": "product_version",
-                        "name": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-                        "product": {
-                          "name": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-                          "product_id": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-                        "product": {
-                          "name": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-                          "product_id": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686"
                         }
                       }
                     ]
@@ -888,28 +871,6 @@
                         "product": {
                           "name": "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.8.1.src",
                           "product_id": "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.8.1.src"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "category": "architecture",
-                    "name": "i686",
-                    "branches": [
-                      {
-                        "category": "product_version",
-                        "name": "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.8.1.i686",
-                        "product": {
-                          "name": "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.8.1.i686",
-                          "product_id": "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.8.1.i686"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.8.1.i686",
-                        "product": {
-                          "name": "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.8.1.i686",
-                          "product_id": "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.8.1.i686"
                         }
                       }
                     ]
@@ -2045,6 +2006,516 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -2096,8 +2567,6 @@
           "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
           "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
           "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.src",
-          "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-          "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
           "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
           "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
           "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.aarch64",
@@ -2158,8 +2627,6 @@
           "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
           "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
           "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.8.1.src",
-          "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.8.1.i686",
-          "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.8.1.i686",
           "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.92ciq_lts.8.1.noarch",
           "lts-9.2:kernel-doc-5.14.0-284.30.1.el9_2.92ciq_lts.8.1.noarch",
           "lts-9.2:kernel-debug-devel-matched-5.14.0-284.30.1.el9_2.92ciq_lts.8.1.x86_64",
@@ -2295,7 +2762,67 @@
           "fips-9.2-compliant:kernel-debug-modules-core-5.14.0-284.30.1.el9_2.ciqfips.0.14.1.x86_64",
           "fips-9.2-compliant:kernel-uki-virt-5.14.0-284.30.1.el9_2.ciqfips.0.14.1.x86_64",
           "fips-9.2-compliant:kernel-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.14.1.x86_64",
-          "fips-9.2-compliant:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.14.1.x86_64"
+          "fips-9.2-compliant:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.14.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
         ]
       },
       "remediations": [
@@ -2336,8 +2863,6 @@
             "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
             "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.src",
-            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.aarch64",
@@ -2398,8 +2923,6 @@
             "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
             "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
             "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.8.1.src",
-            "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.8.1.i686",
-            "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.8.1.i686",
             "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.92ciq_lts.8.1.noarch",
             "lts-9.2:kernel-doc-5.14.0-284.30.1.el9_2.92ciq_lts.8.1.noarch",
             "lts-9.2:kernel-debug-devel-matched-5.14.0-284.30.1.el9_2.92ciq_lts.8.1.x86_64",
@@ -2535,7 +3058,67 @@
             "fips-9.2-compliant:kernel-debug-modules-core-5.14.0-284.30.1.el9_2.ciqfips.0.14.1.x86_64",
             "fips-9.2-compliant:kernel-uki-virt-5.14.0-284.30.1.el9_2.ciqfips.0.14.1.x86_64",
             "fips-9.2-compliant:kernel-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.14.1.x86_64",
-            "fips-9.2-compliant:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.14.1.x86_64"
+            "fips-9.2-compliant:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.14.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
           ]
         }
       ],
@@ -2589,8 +3172,6 @@
             "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
             "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.src",
-            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.aarch64",
@@ -2651,8 +3232,6 @@
             "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
             "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
             "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.8.1.src",
-            "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.8.1.i686",
-            "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.8.1.i686",
             "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.92ciq_lts.8.1.noarch",
             "lts-9.2:kernel-doc-5.14.0-284.30.1.el9_2.92ciq_lts.8.1.noarch",
             "lts-9.2:kernel-debug-devel-matched-5.14.0-284.30.1.el9_2.92ciq_lts.8.1.x86_64",
@@ -2788,7 +3367,67 @@
             "fips-9.2-compliant:kernel-debug-modules-core-5.14.0-284.30.1.el9_2.ciqfips.0.14.1.x86_64",
             "fips-9.2-compliant:kernel-uki-virt-5.14.0-284.30.1.el9_2.ciqfips.0.14.1.x86_64",
             "fips-9.2-compliant:kernel-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.14.1.x86_64",
-            "fips-9.2-compliant:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.14.1.x86_64"
+            "fips-9.2-compliant:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.14.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
           ]
         }
       ],
@@ -2830,8 +3469,6 @@
             "fips-8-compliant:kernel-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
             "fips-8-compliant:kernel-ipaclones-internal-4.18.0-425.13.1.el8.ciqfipscompliant.41.1.x86_64",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.src",
-            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.aarch64",
@@ -2892,8 +3529,6 @@
             "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
             "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
             "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.8.1.src",
-            "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.8.1.i686",
-            "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.8.1.i686",
             "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.92ciq_lts.8.1.noarch",
             "lts-9.2:kernel-doc-5.14.0-284.30.1.el9_2.92ciq_lts.8.1.noarch",
             "lts-9.2:kernel-debug-devel-matched-5.14.0-284.30.1.el9_2.92ciq_lts.8.1.x86_64",
@@ -3029,7 +3664,67 @@
             "fips-9.2-compliant:kernel-debug-modules-core-5.14.0-284.30.1.el9_2.ciqfips.0.14.1.x86_64",
             "fips-9.2-compliant:kernel-uki-virt-5.14.0-284.30.1.el9_2.ciqfips.0.14.1.x86_64",
             "fips-9.2-compliant:kernel-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.14.1.x86_64",
-            "fips-9.2-compliant:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.14.1.x86_64"
+            "fips-9.2-compliant:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.14.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
           ]
         }
       ]

--- a/csaf/vex/cve/2023/cve-2023-45871.json
+++ b/csaf/vex/cve/2023/cve-2023-45871.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-45871",
       "initial_release_date": "2025-06-18T20:43:05Z",
-      "current_release_date": "2025-08-15T22:13:00Z",
+      "current_release_date": "2025-09-05T22:05:42Z",
       "status": "final",
-      "version": "4",
+      "version": "5",
       "revision_history": [
         {
           "date": "2025-06-18T20:43:05Z",
@@ -47,6 +47,11 @@
         {
           "date": "2025-08-15T22:13:00Z",
           "number": "4",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-05T22:05:42Z",
+          "number": "5",
           "summary": "Updated version"
         }
       ]
@@ -76,28 +81,6 @@
                         "product": {
                           "name": "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.src",
                           "product_id": "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.src"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "category": "architecture",
-                    "name": "i686",
-                    "branches": [
-                      {
-                        "category": "product_version",
-                        "name": "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.i686",
-                        "product": {
-                          "name": "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.i686",
-                          "product_id": "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.i686"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.i686",
-                        "product": {
-                          "name": "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.i686",
-                          "product_id": "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.i686"
                         }
                       }
                     ]
@@ -896,28 +879,6 @@
                         "product": {
                           "name": "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.src",
                           "product_id": "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.src"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "category": "architecture",
-                    "name": "i686",
-                    "branches": [
-                      {
-                        "category": "product_version",
-                        "name": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-                        "product": {
-                          "name": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-                          "product_id": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-                        "product": {
-                          "name": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-                          "product_id": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686"
                         }
                       }
                     ]
@@ -2045,6 +2006,516 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ LTS for Rocky Linux 8.6",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "x86_64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -2064,8 +2535,6 @@
       "product_status": {
         "fixed": [
           "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.src",
-          "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.i686",
-          "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.i686",
           "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.noarch",
           "lts-9.2:kernel-doc-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.noarch",
           "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.x86_64",
@@ -2162,8 +2631,6 @@
           "lts-9.2:kernel-64k-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.aarch64",
           "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.aarch64",
           "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.src",
-          "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-          "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
           "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
           "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
           "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.aarch64",
@@ -2295,7 +2762,67 @@
           "fips-9.2-compliant:kernel-uki-virt-5.14.0-284.30.1.el9_2.ciqfips.0.15.1.x86_64",
           "fips-9.2-compliant:kernel-debug-modules-core-5.14.0-284.30.1.el9_2.ciqfips.0.15.1.x86_64",
           "fips-9.2-compliant:kernel-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.15.1.x86_64",
-          "fips-9.2-compliant:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.15.1.x86_64"
+          "fips-9.2-compliant:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.15.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
         ]
       },
       "remediations": [
@@ -2304,8 +2831,6 @@
           "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
           "product_ids": [
             "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.src",
-            "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.i686",
-            "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.i686",
             "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.noarch",
             "lts-9.2:kernel-doc-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.noarch",
             "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.x86_64",
@@ -2402,8 +2927,6 @@
             "lts-9.2:kernel-64k-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.aarch64",
             "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.aarch64",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.src",
-            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.aarch64",
@@ -2535,7 +3058,67 @@
             "fips-9.2-compliant:kernel-uki-virt-5.14.0-284.30.1.el9_2.ciqfips.0.15.1.x86_64",
             "fips-9.2-compliant:kernel-debug-modules-core-5.14.0-284.30.1.el9_2.ciqfips.0.15.1.x86_64",
             "fips-9.2-compliant:kernel-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.15.1.x86_64",
-            "fips-9.2-compliant:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.15.1.x86_64"
+            "fips-9.2-compliant:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.15.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
           ]
         }
       ],
@@ -2557,8 +3140,6 @@
           },
           "products": [
             "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.src",
-            "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.i686",
-            "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.i686",
             "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.noarch",
             "lts-9.2:kernel-doc-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.noarch",
             "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.x86_64",
@@ -2655,8 +3236,6 @@
             "lts-9.2:kernel-64k-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.aarch64",
             "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.aarch64",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.src",
-            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.aarch64",
@@ -2788,7 +3367,67 @@
             "fips-9.2-compliant:kernel-uki-virt-5.14.0-284.30.1.el9_2.ciqfips.0.15.1.x86_64",
             "fips-9.2-compliant:kernel-debug-modules-core-5.14.0-284.30.1.el9_2.ciqfips.0.15.1.x86_64",
             "fips-9.2-compliant:kernel-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.15.1.x86_64",
-            "fips-9.2-compliant:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.15.1.x86_64"
+            "fips-9.2-compliant:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.15.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
           ]
         }
       ],
@@ -2798,8 +3437,6 @@
           "details": "Important",
           "product_ids": [
             "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.src",
-            "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.i686",
-            "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.i686",
             "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.noarch",
             "lts-9.2:kernel-doc-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.noarch",
             "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.x86_64",
@@ -2896,8 +3533,6 @@
             "lts-9.2:kernel-64k-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.aarch64",
             "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.7.1.aarch64",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.src",
-            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.aarch64",
@@ -3029,7 +3664,67 @@
             "fips-9.2-compliant:kernel-uki-virt-5.14.0-284.30.1.el9_2.ciqfips.0.15.1.x86_64",
             "fips-9.2-compliant:kernel-debug-modules-core-5.14.0-284.30.1.el9_2.ciqfips.0.15.1.x86_64",
             "fips-9.2-compliant:kernel-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.15.1.x86_64",
-            "fips-9.2-compliant:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.15.1.x86_64"
+            "fips-9.2-compliant:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.ciqfips.0.15.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
           ]
         }
       ]

--- a/csaf/vex/cve/2023/cve-2023-51042.json
+++ b/csaf/vex/cve/2023/cve-2023-51042.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-51042",
       "initial_release_date": "2024-08-14T19:41:55Z",
-      "current_release_date": "2025-09-04T17:52:16Z",
+      "current_release_date": "2025-09-05T22:05:42Z",
       "status": "final",
-      "version": "7",
+      "version": "8",
       "revision_history": [
         {
           "date": "2024-08-14T19:41:55Z",
@@ -63,6 +63,11 @@
           "date": "2025-09-04T17:52:16Z",
           "number": "7",
           "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-05T22:05:42Z",
+          "number": "8",
+          "summary": "Updated version"
         }
       ]
     }
@@ -91,6 +96,14 @@
                         "product": {
                           "name": "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
                           "product_id": "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src"
                         }
                       }
                     ]
@@ -241,6 +254,490 @@
                         "product": {
                           "name": "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
                           "product_id": "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
                         }
                       }
                     ]
@@ -511,28 +1008,6 @@
                         "product": {
                           "name": "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.src",
                           "product_id": "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.src"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "category": "architecture",
-                    "name": "i686",
-                    "branches": [
-                      {
-                        "category": "product_version",
-                        "name": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
-                        "product": {
-                          "name": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
-                          "product_id": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
-                        "product": {
-                          "name": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
-                          "product_id": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686"
                         }
                       }
                     ]
@@ -1985,6 +2460,7 @@
       "product_status": {
         "fixed": [
           "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
           "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -2003,6 +2479,65 @@
           "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
           "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
           "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
           "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
@@ -2033,8 +2568,6 @@
           "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
           "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.src",
           "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.src",
-          "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
-          "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
           "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
           "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
           "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
@@ -2214,6 +2747,7 @@
           "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
           "product_ids": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -2232,6 +2766,65 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
             "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
@@ -2262,8 +2855,6 @@
             "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.src",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.src",
-            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
-            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
@@ -2456,6 +3047,7 @@
           },
           "products": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -2474,6 +3066,65 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
             "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
@@ -2504,8 +3155,6 @@
             "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.src",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.src",
-            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
-            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
@@ -2686,6 +3335,7 @@
           "details": "Moderate",
           "product_ids": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -2704,6 +3354,65 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
             "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
@@ -2734,8 +3443,6 @@
             "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.src",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.src",
-            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
-            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",

--- a/csaf/vex/cve/2023/cve-2023-5178.json
+++ b/csaf/vex/cve/2023/cve-2023-5178.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-5178",
       "initial_release_date": "2024-12-12T23:24:06Z",
-      "current_release_date": "2025-07-14T22:17:03Z",
+      "current_release_date": "2025-09-05T22:05:43Z",
       "status": "final",
-      "version": "7",
+      "version": "8",
       "revision_history": [
         {
           "date": "2024-12-12T23:24:06Z",
@@ -62,6 +62,11 @@
         {
           "date": "2025-07-14T22:17:03Z",
           "number": "7",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-05T22:05:43Z",
+          "number": "8",
           "summary": "Updated version"
         }
       ]
@@ -99,28 +104,6 @@
                         "product": {
                           "name": "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.src",
                           "product_id": "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.src"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "category": "architecture",
-                    "name": "i686",
-                    "branches": [
-                      {
-                        "category": "product_version",
-                        "name": "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.i686",
-                        "product": {
-                          "name": "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.i686",
-                          "product_id": "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.i686"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.i686",
-                        "product": {
-                          "name": "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.i686",
-                          "product_id": "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.i686"
                         }
                       }
                     ]
@@ -1099,26 +1082,6 @@
               },
               {
                 "category": "product_name",
-                "name": "CIQ Bridge",
-                "branches": [
-                  {
-                    "category": "architecture",
-                    "name": "src",
-                    "branches": [
-                      {
-                        "category": "product_version",
-                        "name": "cbr-7.9:kernel",
-                        "product": {
-                          "name": "cbr-7.9:kernel",
-                          "product_id": "cbr-7.9:kernel"
-                        }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "category": "product_name",
                 "name": "CIQ LTS for Rocky Linux 8.6",
                 "branches": [
                   {
@@ -1131,6 +1094,14 @@
                         "product": {
                           "name": "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.src",
                           "product_id": "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src"
                         }
                       }
                     ]
@@ -1281,6 +1252,490 @@
                         "product": {
                           "name": "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
                           "product_id": "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
                         }
                       }
                     ]
@@ -1697,28 +2152,6 @@
                   },
                   {
                     "category": "architecture",
-                    "name": "i686",
-                    "branches": [
-                      {
-                        "category": "product_version",
-                        "name": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-                        "product": {
-                          "name": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-                          "product_id": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-                        "product": {
-                          "name": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-                          "product_id": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "category": "architecture",
                     "name": "noarch",
                     "branches": [
                       {
@@ -1970,6 +2403,26 @@
                     ]
                   }
                 ]
+              },
+              {
+                "category": "product_name",
+                "name": "CIQ Bridge",
+                "branches": [
+                  {
+                    "category": "architecture",
+                    "name": "src",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "cbr-7.9:kernel",
+                        "product": {
+                          "name": "cbr-7.9:kernel",
+                          "product_id": "cbr-7.9:kernel"
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -1992,8 +2445,7 @@
         ],
         "fixed": [
           "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.src",
-          "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.i686",
-          "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.i686",
+          "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.src",
           "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.noarch",
           "lts-9.2:kernel-doc-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.noarch",
           "lts-9.2:kernel-debug-devel-matched-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.x86_64",
@@ -2034,6 +2486,30 @@
           "lts-9.2:kernel-uki-virt-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.x86_64",
           "lts-9.2:kernel-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.x86_64",
           "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.x86_64",
+          "lts-9.2:kernel-rt-debug-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debug-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debug-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debug-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debug-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debug-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-selftests-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debug-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debug-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debuginfo-common-x86_64-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debug-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debug-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+          "lts-9.2:kernel-rt-debug-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
           "lts-9.2:kernel-64k-devel-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
           "lts-9.2:kernel-64k-debug-devel-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
           "lts-9.2:kernel-selftests-internal-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
@@ -2089,32 +2565,8 @@
           "lts-9.2:kernel-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
           "lts-9.2:kernel-64k-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
           "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
-          "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.src",
-          "lts-9.2:kernel-rt-debug-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debug-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debug-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debug-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debug-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debug-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-selftests-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debug-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debug-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debuginfo-common-x86_64-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debug-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debug-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-          "lts-9.2:kernel-rt-debug-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
           "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.src",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
           "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
           "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
           "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
@@ -2133,7 +2585,67 @@
           "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
           "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
           "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
           "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.src",
+          "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.src",
           "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
           "lts-8.8:kernel-rt-debuginfo-common-x86_64-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
           "lts-8.8:kernel-rt-selftests-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
@@ -2152,9 +2664,35 @@
           "lts-8.8:kernel-rt-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
           "lts-8.8:kernel-rt-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
           "lts-8.8:kernel-rt-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-          "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.src",
-          "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-          "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
+          "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+          "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+          "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+          "lts-8.8:kernel-debuginfo-common-x86_64-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+          "lts-8.8:perf-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+          "lts-8.8:perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+          "lts-8.8:python3-perf-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+          "lts-8.8:python3-perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+          "lts-8.8:kernel-tools-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+          "lts-8.8:kernel-tools-libs-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+          "lts-8.8:kernel-tools-libs-devel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+          "lts-8.8:kernel-tools-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+          "lts-8.8:bpftool-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+          "lts-8.8:bpftool-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+          "lts-8.8:kernel-selftests-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+          "lts-8.8:kernel-debug-core-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+          "lts-8.8:kernel-debug-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+          "lts-8.8:kernel-debug-devel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+          "lts-8.8:kernel-debug-modules-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+          "lts-8.8:kernel-debug-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+          "lts-8.8:kernel-debug-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+          "lts-8.8:kernel-debug-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+          "lts-8.8:kernel-core-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+          "lts-8.8:kernel-devel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+          "lts-8.8:kernel-modules-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+          "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+          "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+          "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+          "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
           "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
           "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
           "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.aarch64",
@@ -2184,36 +2722,7 @@
           "lts-8.8:kernel-modules-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.aarch64",
           "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.aarch64",
           "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.aarch64",
-          "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.aarch64",
-          "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-          "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-          "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-          "lts-8.8:kernel-debuginfo-common-x86_64-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-          "lts-8.8:perf-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-          "lts-8.8:perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-          "lts-8.8:python3-perf-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-          "lts-8.8:python3-perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-          "lts-8.8:kernel-tools-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-          "lts-8.8:kernel-tools-libs-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-          "lts-8.8:kernel-tools-libs-devel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-          "lts-8.8:kernel-tools-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-          "lts-8.8:bpftool-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-          "lts-8.8:bpftool-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-          "lts-8.8:kernel-selftests-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-          "lts-8.8:kernel-debug-core-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-          "lts-8.8:kernel-debug-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-          "lts-8.8:kernel-debug-devel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-          "lts-8.8:kernel-debug-modules-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-          "lts-8.8:kernel-debug-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-          "lts-8.8:kernel-debug-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-          "lts-8.8:kernel-debug-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-          "lts-8.8:kernel-core-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-          "lts-8.8:kernel-devel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-          "lts-8.8:kernel-modules-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-          "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-          "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-          "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-          "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64"
+          "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.aarch64"
         ]
       },
       "remediations": [
@@ -2222,8 +2731,7 @@
           "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
           "product_ids": [
             "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.src",
-            "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.i686",
-            "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.i686",
+            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.src",
             "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.noarch",
             "lts-9.2:kernel-doc-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.noarch",
             "lts-9.2:kernel-debug-devel-matched-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.x86_64",
@@ -2264,6 +2772,30 @@
             "lts-9.2:kernel-uki-virt-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.x86_64",
             "lts-9.2:kernel-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.x86_64",
             "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.x86_64",
+            "lts-9.2:kernel-rt-debug-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-selftests-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debuginfo-common-x86_64-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
             "lts-9.2:kernel-64k-devel-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
             "lts-9.2:kernel-64k-debug-devel-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
             "lts-9.2:kernel-selftests-internal-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
@@ -2319,32 +2851,8 @@
             "lts-9.2:kernel-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
             "lts-9.2:kernel-64k-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
             "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
-            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.src",
-            "lts-9.2:kernel-rt-debug-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-selftests-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debuginfo-common-x86_64-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
@@ -2363,7 +2871,67 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
             "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.src",
+            "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.src",
             "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
             "lts-8.8:kernel-rt-debuginfo-common-x86_64-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
             "lts-8.8:kernel-rt-selftests-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
@@ -2382,9 +2950,35 @@
             "lts-8.8:kernel-rt-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
             "lts-8.8:kernel-rt-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
             "lts-8.8:kernel-rt-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.src",
-            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
+            "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-debuginfo-common-x86_64-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:perf-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:python3-perf-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:python3-perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-tools-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-tools-libs-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-tools-libs-devel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-tools-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:bpftool-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:bpftool-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-selftests-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-debug-core-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-debug-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-debug-devel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-debug-modules-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-debug-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-debug-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-debug-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-core-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-devel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-modules-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.aarch64",
@@ -2414,36 +3008,7 @@
             "lts-8.8:kernel-modules-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.aarch64",
             "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.aarch64",
             "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.aarch64",
-            "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.aarch64",
-            "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-debuginfo-common-x86_64-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:perf-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:python3-perf-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:python3-perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-tools-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-tools-libs-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-tools-libs-devel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-tools-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:bpftool-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:bpftool-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-selftests-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-debug-core-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-debug-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-debug-devel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-debug-modules-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-debug-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-debug-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-debug-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-core-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-devel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-modules-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64"
+            "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.aarch64"
           ]
         }
       ],
@@ -2465,8 +3030,7 @@
           },
           "products": [
             "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.src",
-            "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.i686",
-            "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.i686",
+            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.src",
             "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.noarch",
             "lts-9.2:kernel-doc-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.noarch",
             "lts-9.2:kernel-debug-devel-matched-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.x86_64",
@@ -2507,6 +3071,30 @@
             "lts-9.2:kernel-uki-virt-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.x86_64",
             "lts-9.2:kernel-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.x86_64",
             "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.x86_64",
+            "lts-9.2:kernel-rt-debug-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-selftests-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debuginfo-common-x86_64-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
             "lts-9.2:kernel-64k-devel-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
             "lts-9.2:kernel-64k-debug-devel-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
             "lts-9.2:kernel-selftests-internal-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
@@ -2562,32 +3150,8 @@
             "lts-9.2:kernel-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
             "lts-9.2:kernel-64k-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
             "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
-            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.src",
-            "lts-9.2:kernel-rt-debug-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-selftests-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debuginfo-common-x86_64-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
@@ -2606,7 +3170,67 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
             "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.src",
+            "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.src",
             "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
             "lts-8.8:kernel-rt-debuginfo-common-x86_64-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
             "lts-8.8:kernel-rt-selftests-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
@@ -2625,9 +3249,35 @@
             "lts-8.8:kernel-rt-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
             "lts-8.8:kernel-rt-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
             "lts-8.8:kernel-rt-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.src",
-            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
+            "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-debuginfo-common-x86_64-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:perf-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:python3-perf-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:python3-perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-tools-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-tools-libs-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-tools-libs-devel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-tools-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:bpftool-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:bpftool-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-selftests-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-debug-core-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-debug-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-debug-devel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-debug-modules-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-debug-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-debug-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-debug-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-core-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-devel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-modules-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.aarch64",
@@ -2657,36 +3307,7 @@
             "lts-8.8:kernel-modules-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.aarch64",
             "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.aarch64",
             "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.aarch64",
-            "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.aarch64",
-            "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-debuginfo-common-x86_64-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:perf-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:python3-perf-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:python3-perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-tools-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-tools-libs-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-tools-libs-devel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-tools-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:bpftool-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:bpftool-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-selftests-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-debug-core-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-debug-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-debug-devel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-debug-modules-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-debug-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-debug-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-debug-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-core-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-devel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-modules-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64"
+            "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.aarch64"
           ]
         }
       ],
@@ -2696,8 +3317,7 @@
           "details": "Important",
           "product_ids": [
             "lts-9.2:kernel-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.src",
-            "lts-9.2:kernel-headers-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.i686",
-            "lts-9.2:kernel-cross-headers-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.i686",
+            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.src",
             "lts-9.2:kernel-abi-stablelists-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.noarch",
             "lts-9.2:kernel-doc-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.noarch",
             "lts-9.2:kernel-debug-devel-matched-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.x86_64",
@@ -2738,6 +3358,30 @@
             "lts-9.2:kernel-uki-virt-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.x86_64",
             "lts-9.2:kernel-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.x86_64",
             "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.x86_64",
+            "lts-9.2:kernel-rt-debug-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-selftests-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debuginfo-common-x86_64-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
+            "lts-9.2:kernel-rt-debug-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
             "lts-9.2:kernel-64k-devel-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
             "lts-9.2:kernel-64k-debug-devel-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
             "lts-9.2:kernel-selftests-internal-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
@@ -2793,32 +3437,8 @@
             "lts-9.2:kernel-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
             "lts-9.2:kernel-64k-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
             "lts-9.2:kernel-debug-debuginfo-5.14.0-284.30.1.el9_2.92ciq_lts.3.1.aarch64",
-            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.src",
-            "lts-9.2:kernel-rt-debug-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-devel-matched-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-partner-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-extra-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-kvm-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-selftests-internal-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-devel-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debuginfo-common-x86_64-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-modules-core-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-modules-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
-            "lts-9.2:kernel-rt-debug-debuginfo-5.14.0-284.30.1.rt14.315.el9_2.92ciq_lts.2.2.x86_64",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
@@ -2837,7 +3457,67 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.4.1.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
             "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.src",
+            "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.src",
             "lts-8.8:kernel-rt-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
             "lts-8.8:kernel-rt-debuginfo-common-x86_64-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
             "lts-8.8:kernel-rt-selftests-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
@@ -2856,9 +3536,35 @@
             "lts-8.8:kernel-rt-modules-internal-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
             "lts-8.8:kernel-rt-debuginfo-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
             "lts-8.8:kernel-rt-kvm-4.18.0-477.27.1.rt7.290.el8_8.88ciq_lts.2.1.x86_64",
-            "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.src",
-            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
-            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.i686",
+            "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-debuginfo-common-x86_64-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:perf-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:python3-perf-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:python3-perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-tools-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-tools-libs-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-tools-libs-devel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-tools-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:bpftool-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:bpftool-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-selftests-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-debug-core-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-debug-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-debug-devel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-debug-modules-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-debug-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-debug-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-debug-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-core-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-devel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-modules-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
+            "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.noarch",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.aarch64",
@@ -2888,36 +3594,7 @@
             "lts-8.8:kernel-modules-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.aarch64",
             "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.aarch64",
             "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.aarch64",
-            "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.aarch64",
-            "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-debuginfo-common-x86_64-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:perf-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:python3-perf-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:python3-perf-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-tools-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-tools-libs-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-tools-libs-devel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-tools-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:bpftool-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:bpftool-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-selftests-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-debug-core-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-debug-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-debug-devel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-debug-modules-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-debug-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-debug-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-debug-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-core-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-devel-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-modules-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-modules-extra-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-modules-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64",
-            "lts-8.8:kernel-ipaclones-internal-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.x86_64"
+            "lts-8.8:kernel-debuginfo-4.18.0-477.27.1.el8_8.88ciq_lts.6.1.aarch64"
           ]
         }
       ]

--- a/csaf/vex/cve/2023/cve-2023-6546.json
+++ b/csaf/vex/cve/2023/cve-2023-6546.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-6546",
       "initial_release_date": "2024-08-14T19:41:55Z",
-      "current_release_date": "2025-06-04T20:19:16Z",
+      "current_release_date": "2025-09-05T22:05:43Z",
       "status": "final",
-      "version": "5",
+      "version": "6",
       "revision_history": [
         {
           "date": "2024-08-14T19:41:55Z",
@@ -52,6 +52,11 @@
         {
           "date": "2025-06-04T20:19:16Z",
           "number": "5",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-05T22:05:43Z",
+          "number": "6",
           "summary": "Updated version"
         }
       ]
@@ -81,6 +86,14 @@
                         "product": {
                           "name": "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
                           "product_id": "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src"
                         }
                       }
                     ]
@@ -231,6 +244,490 @@
                         "product": {
                           "name": "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
                           "product_id": "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
                         }
                       }
                     ]
@@ -501,28 +998,6 @@
                         "product": {
                           "name": "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.src",
                           "product_id": "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.src"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "category": "architecture",
-                    "name": "i686",
-                    "branches": [
-                      {
-                        "category": "product_version",
-                        "name": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
-                        "product": {
-                          "name": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
-                          "product_id": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
-                        "product": {
-                          "name": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
-                          "product_id": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686"
                         }
                       }
                     ]
@@ -1037,6 +1512,7 @@
       "product_status": {
         "fixed": [
           "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
           "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -1055,6 +1531,65 @@
           "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
           "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
           "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
           "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
@@ -1085,8 +1620,6 @@
           "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
           "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.src",
           "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.src",
-          "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
-          "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
           "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
           "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
           "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
@@ -1154,6 +1687,7 @@
           "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
           "product_ids": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -1172,6 +1706,65 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
             "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
@@ -1202,8 +1795,6 @@
             "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.src",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.src",
-            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
-            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
@@ -1284,6 +1875,7 @@
           },
           "products": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -1302,6 +1894,65 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
             "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
@@ -1332,8 +1983,6 @@
             "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.src",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.src",
-            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
-            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
@@ -1402,6 +2051,7 @@
           "details": "Important",
           "product_ids": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -1420,6 +2070,65 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
             "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
@@ -1450,8 +2159,6 @@
             "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.src",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.src",
-            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
-            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",

--- a/csaf/vex/cve/2023/cve-2023-6931.json
+++ b/csaf/vex/cve/2023/cve-2023-6931.json
@@ -25,9 +25,9 @@
     "tracking": {
       "id": "CVE-2023-6931",
       "initial_release_date": "2024-08-14T19:41:55Z",
-      "current_release_date": "2025-06-04T20:19:16Z",
+      "current_release_date": "2025-09-05T22:05:43Z",
       "status": "final",
-      "version": "5",
+      "version": "6",
       "revision_history": [
         {
           "date": "2024-08-14T19:41:55Z",
@@ -52,6 +52,11 @@
         {
           "date": "2025-06-04T20:19:16Z",
           "number": "5",
+          "summary": "Updated version"
+        },
+        {
+          "date": "2025-09-05T22:05:43Z",
+          "number": "6",
           "summary": "Updated version"
         }
       ]
@@ -81,6 +86,14 @@
                         "product": {
                           "name": "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
                           "product_id": "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src"
                         }
                       }
                     ]
@@ -231,6 +244,490 @@
                         "product": {
                           "name": "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
                           "product_id": "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                        "product": {
+                          "name": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+                          "product_id": "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "noarch",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                        "product": {
+                          "name": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+                          "product_id": "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "category": "architecture",
+                    "name": "aarch64",
+                    "branches": [
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
+                        }
+                      },
+                      {
+                        "category": "product_version",
+                        "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                        "product": {
+                          "name": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+                          "product_id": "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64"
                         }
                       }
                     ]
@@ -501,28 +998,6 @@
                         "product": {
                           "name": "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.src",
                           "product_id": "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.src"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "category": "architecture",
-                    "name": "i686",
-                    "branches": [
-                      {
-                        "category": "product_version",
-                        "name": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
-                        "product": {
-                          "name": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
-                          "product_id": "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686"
-                        }
-                      },
-                      {
-                        "category": "product_version",
-                        "name": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
-                        "product": {
-                          "name": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
-                          "product_id": "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686"
                         }
                       }
                     ]
@@ -1037,6 +1512,7 @@
       "product_status": {
         "fixed": [
           "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
           "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -1055,6 +1531,65 @@
           "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
           "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+          "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+          "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+          "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
           "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
           "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
           "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
@@ -1085,8 +1620,6 @@
           "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
           "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.src",
           "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.src",
-          "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
-          "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
           "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
           "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
           "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
@@ -1154,6 +1687,7 @@
           "details": "CIQ has released new versions of the affected packages, please update the packages to the newest version from Mountain.",
           "product_ids": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -1172,6 +1706,65 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
             "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
@@ -1202,8 +1795,6 @@
             "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.src",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.src",
-            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
-            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
@@ -1284,6 +1875,7 @@
           },
           "products": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -1302,6 +1894,65 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
             "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
@@ -1332,8 +1983,6 @@
             "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.src",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.src",
-            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
-            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",
@@ -1402,6 +2051,7 @@
           "details": "Moderate",
           "product_ids": [
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.src",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.src",
             "lts-8.6:kernel-rt-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-common-x86_64-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-selftests-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
@@ -1420,6 +2070,65 @@
             "lts-8.6:kernel-rt-modules-internal-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-debuginfo-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
             "lts-8.6:kernel-rt-kvm-4.18.0-372.34.1.rt7.190.el8_6.86ciq_lts.0.2.x86_64",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-common-x86_64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-ipaclones-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.x86_64",
+            "lts-8.6:kernel-doc-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-abi-stablelists-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.noarch",
+            "lts-8.6:kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-cross-headers-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-common-aarch64-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:python3-perf-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-libs-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-tools-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:bpftool-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-selftests-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debug-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-core-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-devel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-extra-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-modules-internal-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
+            "lts-8.6:kernel-debuginfo-4.18.0-372.32.1.el8_6.86ciq_lts.8.1.aarch64",
             "fips-8-compliant:bpftool-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:bpftool-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
@@ -1450,8 +2159,6 @@
             "fips-8-compliant:python3-perf-debuginfo-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.x86_64",
             "fips-8-compliant:kernel-4.18.0-425.13.1.el8.ciqfipscompliant.0.34.src",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.src",
-            "lts-8.8:kernel-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
-            "lts-8.8:kernel-cross-headers-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.i686",
             "lts-8.8:kernel-doc-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
             "lts-8.8:kernel-abi-stablelists-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.noarch",
             "lts-8.8:kernel-4.18.0-477.27.1.el8_8.88ciq_lts.2.1.x86_64",


### PR DESCRIPTION
These CVEs were completed prior to the CSAF project getting into full swing.  We know via release tagging in the kernel-src-tree which binaries they're associated.  We picked CSAF files if they had the same NVR (save some minor variation) to get the all the binary file names. If we had a release that does not seem to be represented in CSAF we picked the nearest one that existed and used those binary file names.

Kernels with NVR 4.18.0-372.32.1.0.5 we could match. Kernels with NVR 4.18.0-372.32.1.0.6 we could not and used a newer kernel NVR:
 kernel-4.18.0-372.32.1.el8_6.86ciq_lts.8.1

The original binary list is no longer accessible to have a 1:1 match

